### PR TITLE
Feature: Custom file output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(chimera
   src/configuration.cpp
   src/consumer.cpp
   src/frontend_action.cpp
+  src/stream.cpp
   src/visitor.cpp
   src/util.cpp
 )

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 **On Ubuntu**
 
-```
+```bash
 sudo add-apt-repository 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main'
 wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get install llvm-3.6-dev llvm-3.6-tools libclang-3.6-dev libedit-dev libyaml-cpp-dev
@@ -32,12 +32,47 @@ PKG_CONFIG_PATH=/usr/local/Cellar/yaml-cpp/0.5.2/lib/pkgconfig cmake -DLLVM_DIR=
 ## Usage ##
 Let's try running chimera on itself!
 
-```
+```bash
 $ cd [PATH TO CHIMERA]
 $ rm -rf build && mkdir -p build && cd build
 $ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
 $ make
 $ chimera -p . -o chimera_py_binding.cpp ../src/chimera.cpp
+```
+
+## Configuration ##
+```yaml
+# Arguments that will be appended in-order before command line arguments.
+# (Not implemented yet.)
+arguments:
+  - "-extra-arg"
+  - "-I/usr/lib/clang/3.6/include"
+
+# The C++ namespaces that will be extracted by Chimera
+namespaces:
+  - dart::dynamics
+  - dart::math
+
+# Selected types that should have special handling.
+# (Not implemented yet.)
+types:
+  'class BodyNode':
+    convert_to: 'class BodyNodePtr'
+
+# Selected function and class declarations that need custom parameters.
+declarations:
+  'const Eigen::Vector4d & ::dart::dynamics::Shape::getRGBA() const':
+    return_value_policy: ::boost::python::copy_const_reference
+  'bool ::dart::dynamics::Skeleton::isImpulseApplied() const':
+    source: 'test.cpp.in'
+  'const Eigen::Vector3d & ::dart::dynamics::Shape::getBoundingBoxDim() const':
+    content: '/* Instead of implementing this function, insert this comment! */'
+  'Eigen::VectorXd & ::dart::optimizer::GradientDescentSolver::getEqConstraintWeights()': ~
+    # This declaration will be suppressed.
+  '::dart::dynamics::Shape':
+    name: Shape
+    bases: []
+    noncopyable: true
 ```
 
 ## Troubleshooting ##

--- a/include/chimera/configuration.h
+++ b/include/chimera/configuration.h
@@ -1,6 +1,8 @@
 #ifndef __CHIMERA_CONFIGURATION_H__
 #define __CHIMERA_CONFIGURATION_H__
 
+#include "chimera/stream.h"
+
 #include <clang/AST/DeclBase.h>
 #include <clang/AST/Mangle.h>
 #include <clang/Frontend/CompilerInstance.h>
@@ -9,15 +11,9 @@
 #include <set>
 #include <yaml-cpp/yaml.h>
 
-// Forward declare LLVM raw_ostream, as per:
-// http://llvm.org/docs/CodingStandards.html#use-raw-ostream
-namespace llvm
-{
-class raw_pwrite_stream;
-}
-
 namespace chimera
 {
+
 class CompiledConfiguration;
 
 class Configuration
@@ -39,7 +35,8 @@ public:
     /**
      * Process the configuration settings against the current AST.
      */
-    std::unique_ptr<CompiledConfiguration> Process(clang::CompilerInstance *ci) const;
+    std::unique_ptr<CompiledConfiguration>
+    Process(clang::CompilerInstance *ci, clang::StringRef file) const;
 
     /**
      * Get the root node of the YAML configuration structure.
@@ -85,14 +82,27 @@ public:
      *
      * The file pointer should be closed after the output has been written.
      */
-    llvm::raw_pwrite_stream *GetOutputFile(const clang::Decl *decl) const;
+    std::unique_ptr<Stream>GetOutputFile(const clang::Decl *decl) const;
+
+    /**
+     * Dump any hard-coded overrides in place of this declaration, if they
+     * are defined in the `content` (for strings) or `source` (for files)
+     * fields of the YAML configuration for this declaration.
+     *
+     * Returns `true` if an override was found and dumped, `false` otherwise.
+     */
+    bool DumpOverride(const clang::Decl *decl, chimera::Stream &stream) const;
 
 private:
-    CompiledConfiguration(clang::CompilerInstance *ci);
+    CompiledConfiguration(const Configuration &parent,
+                          clang::CompilerInstance *ci,
+                          clang::StringRef file);
 
 protected:
     static const YAML::Node emptyNode_;
+    const Configuration &parent_;
     clang::CompilerInstance *ci_;
+    const clang::StringRef file_;
     std::map<const clang::Decl*, YAML::Node> declarations_;
     std::set<const clang::NamespaceDecl*> namespaces_;
     std::unique_ptr<clang::MangleContext> mangler_;

--- a/include/chimera/consumer.h
+++ b/include/chimera/consumer.h
@@ -11,13 +11,14 @@ class Consumer : public clang::ASTConsumer
 {
 public:
     // Overrides the constructor in order to receive CompilerInstance.
-    explicit Consumer(clang::CompilerInstance *ci);
+    Consumer(clang::CompilerInstance *ci, clang::StringRef file);
 
     // Overrides method to call our ChimeraVisitor on the entire source file.
-    virtual void HandleTranslationUnit(clang::ASTContext &context);
+    void HandleTranslationUnit(clang::ASTContext &context) override;
 
 private:
     clang::CompilerInstance *ci_;
+    clang::StringRef file_;
 };
 
 } // namespace chimera

--- a/include/chimera/stream.h
+++ b/include/chimera/stream.h
@@ -1,0 +1,50 @@
+#ifndef __CHIMERA_STREAM_H__
+#define __CHIMERA_STREAM_H__
+
+#include <string>
+
+// Forward declare LLVM raw_ostream, as per:
+// http://llvm.org/docs/CodingStandards.html#use-raw-ostream
+namespace llvm
+{
+class raw_ostream;
+}
+
+namespace
+{
+typedef llvm::raw_ostream StreamType;
+}
+
+namespace chimera
+{
+
+/**
+ * Opaque stream type that forwards to internal file stream.
+ */
+class Stream
+{
+public:
+    Stream(StreamType *stream,
+           const std::string &includeName,
+           const std::string &mangledName);
+    virtual ~Stream();
+
+    Stream(const Stream&) = delete;
+    void operator=(const Stream&) = delete;
+
+    template<typename T> Stream& operator<<(const T& obj);
+
+private:
+    StreamType *stream_; // Pointer to actual stream type.
+};
+
+
+template<typename T> Stream& Stream::operator<<(const T& obj)
+{
+    *stream_ << obj;
+    return *this;
+}
+
+} // namespace chimera
+
+#endif // __CHIMERA_STREAM_H__

--- a/include/chimera/visitor.h
+++ b/include/chimera/visitor.h
@@ -7,13 +7,6 @@
 #include <clang/AST/RecursiveASTVisitor.h>
 #include <clang/Frontend/CompilerInstance.h>
 
-// Forward declare LLVM raw_ostream, as per:
-// http://llvm.org/docs/CodingStandards.html#use-raw-ostream
-namespace llvm
-{
-class raw_pwrite_stream;
-}
-
 namespace chimera
 {
 
@@ -27,16 +20,16 @@ public:
 
 protected:
     bool GenerateCXXRecord(clang::CXXRecordDecl *decl);
-    bool GenerateCXXConstructor(llvm::raw_pwrite_stream &stream,
+    bool GenerateCXXConstructor(chimera::Stream &stream,
                                 clang::CXXRecordDecl *class_decl,
                                 clang::CXXConstructorDecl *decl);
-    bool GenerateFunction(llvm::raw_pwrite_stream &stream,
+    bool GenerateFunction(chimera::Stream &stream,
                            clang::CXXRecordDecl *class_decl,
                            clang::FunctionDecl *decl);
-    bool GenerateField(llvm::raw_pwrite_stream &stream,
+    bool GenerateField(chimera::Stream &stream,
                        clang::CXXRecordDecl *class_decl,
                        clang::FieldDecl *decl);
-    bool GenerateStaticField(llvm::raw_pwrite_stream &stream,
+    bool GenerateStaticField(chimera::Stream &stream,
                              clang::CXXRecordDecl *class_decl,
                              clang::VarDecl *decl);
 

--- a/src/chimera.cpp
+++ b/src/chimera.cpp
@@ -4,9 +4,9 @@
 #include "chimera/configuration.h"
 #include "chimera/frontend_action.h"
 
-#include "clang/Tooling/CommonOptionsParser.h"
-#include "clang/Tooling/Tooling.h"
-#include "llvm/Support/CommandLine.h"
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <llvm/Support/CommandLine.h>
 
 #include <memory>
 #include <string>

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -6,8 +6,8 @@
 
 using namespace clang;
 
-chimera::Consumer::Consumer(CompilerInstance *ci)
-: ci_(ci)
+chimera::Consumer::Consumer(CompilerInstance *ci, StringRef file)
+: ci_(ci), file_(file)
 { 
     // Do nothing.
 }
@@ -16,7 +16,7 @@ void chimera::Consumer::HandleTranslationUnit(ASTContext &context)
 {
     // Use the current translation unit to resolve the YAML configuration.
     chimera::Configuration &config = chimera::Configuration::GetInstance();
-    chimera::Visitor visitor(ci_, config.Process(ci_));
+    chimera::Visitor visitor(ci_, config.Process(ci_, file_));
 
     // TODO: Remove this debug print.
     std::cout << "\n\n---\n\n";

--- a/src/frontend_action.cpp
+++ b/src/frontend_action.cpp
@@ -9,5 +9,5 @@ std::unique_ptr<clang::ASTConsumer>
 chimera::FrontendAction::CreateASTConsumer(CompilerInstance &CI, StringRef file) 
 {
     CI.getPreprocessor().getDiagnostics().setIgnoreAllWarnings(true);
-    return std::unique_ptr<chimera::Consumer>(new chimera::Consumer(&CI));
+    return std::unique_ptr<chimera::Consumer>(new chimera::Consumer(&CI, file));
 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1,0 +1,19 @@
+#include "chimera/stream.h"
+
+#include <llvm/Support/raw_ostream.h>
+
+chimera::Stream::Stream(StreamType *stream,
+                        const std::string &includeName,
+                        const std::string &mangledName)
+: stream_(stream)
+{
+    *stream_ << "#include <" << includeName << ">\n"
+                "\n"
+                "void " << mangledName << "()\n"
+                "{\n";
+}
+
+chimera::Stream::~Stream()
+{
+    *stream_ << "}\n";
+}

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -12,8 +12,8 @@ namespaces:
 declarations:
   'const Eigen::Vector4d & ::dart::dynamics::Shape::getRGBA() const':
     return_value_policy: ::boost::python::copy_const_reference
-  'const Eigen::Vector3d & ::dart::dynamics::Shape::getBoundingBoxDim() const':
-    source: 'test.cpp.in'
+  'bool ::dart::dynamics::Skeleton::isImpulseApplied() const':
+    source: '/home/parallels/ws/src/kludge/test/test.cpp.in'
   'const Eigen::Vector3d & ::dart::dynamics::Shape::getBoundingBoxDim() const':
     content: '/* Definitely not implementing this function! */'  
   'Eigen::VectorXd & ::dart::optimizer::GradientDescentSolver::getEqConstraintWeights()': ~


### PR DESCRIPTION
- Added ability to add `content` (embedded string) and `source` (embedded file) declaration overrides.
- Wrapped open definitions in a `unique_ptr` that generates the header and class definition wrapper.
- Changed to use the input file as includes instead of all linked files.
