### PR TITLE
Fixed generation of invalid default arguments.

### DIFF
--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -188,7 +188,7 @@ void GenerateFunctionArguments(
                 use_param_default = true;
 
             // If we reached the parameters with default arguments, write them.
-            if (use_param_default && !param_it->second.empty())
+            if (use_param_default)
                 python_arg << " = " << param_it->second;
 
             // Record this entry to the list of parameter declarations.


### PR DESCRIPTION
This fixes a bug where default arguments that were unresolved
could occur after default arguments that were resolved.  This
would lead to output like:

`_arg("a") = "foo", _arg("b"), _arg("c") = "bar"`

which would not be a valid set of default arguments.  The fix
searches for the last unresolved argument in the parameter list,
and only provides defaults for parameters after this one.
