### PR TITLE
Make const types non-assignable

### DIFF
--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -29,7 +29,9 @@ bool IsAssignable(CXXRecordDecl *decl)
 
 bool IsQualTypeAssignable(ASTContext &context, QualType qual_type)
 {
-    if (CXXRecordDecl *decl = qual_type.getTypePtr()->getAsCXXRecordDecl())
+    if (qual_type.isConstQualified())
+        return false;
+    else if (CXXRecordDecl *decl = qual_type.getTypePtr()->getAsCXXRecordDecl())
         return IsAssignable(decl);
     else if (qual_type.getTypePtr()->isArrayType())
         return false;


### PR DESCRIPTION
This fixes #43. I believe this was a regression introduced in #42.
