### PR TITLE
Added configuration snippets for main binding.cpp.

### DIFF
--- a/test/test.yaml
+++ b/test/test.yaml
@@ -10,6 +10,12 @@ template:
     content: '/* postinclude */'
   footer:
     content: '/* footer */'
+  main_header:
+    content: '/* main header */'
+  main_postinclude:
+    content: '/* main postinclude */'
+  main_footer:
+    content: '/* main footer */'
 
 # The C++ namespaces that will be extracted by Chimera
 namespaces:


### PR DESCRIPTION
This adds special `main_` arguments to the `template` configuration
block that can be used to specify custom code that should only be
inserted into the main binding `.cpp` file.

This closes #48.
