### PR TITLE
Added command line argument to be able to specify enclosing namespaces.

### DIFF
--- a/include/chimera/configuration.h
+++ b/include/chimera/configuration.h
@@ -58,6 +58,12 @@ public:
     void SetOutputModuleName(const std::string &moduleName);
 
     /**
+     * Append an enclosing namespace that should be generated as part
+     * of the top-level binding.
+     */
+    void AddInputNamespaceName(const std::string &namespaceName);
+
+    /**
      * Process the configuration settings against the current AST.
      */
     std::unique_ptr<CompiledConfiguration>
@@ -76,7 +82,7 @@ public:
     /**
      * Get the desired output path for bindings.
      */
-    const std::string &GetOutputPath() const;
+    const std::string& GetOutputPath() const;
 
     /**
      * Get the desired output python module name for top-level binding.
@@ -91,6 +97,9 @@ protected:
     std::string configFilename_;
     std::string outputPath_;
     std::string outputModuleName_;
+    std::vector<std::string> inputNamespaceNames_;
+
+    friend class CompiledConfiguration;
 };
 
 class CompiledConfiguration

--- a/src/chimera.cpp
+++ b/src/chimera.cpp
@@ -35,6 +35,12 @@ static cl::opt<std::string> OutputModuleName(
     cl::desc("Specify output top-level module name"),
     cl::value_desc("modulename"));
 
+// Option for specifying top-level binding namespaces.
+static cl::list<std::string> NamespaceNames(
+    "n", cl::cat(ChimeraCategory),
+    cl::desc("Specify one or more top-level namespaces that will be bound"),
+    cl::value_desc("namespace"));
+
 // Option for specifying YAML configuration filename.
 static cl::opt<std::string> ConfigFilename(
     "c", cl::cat(ChimeraCategory),
@@ -70,6 +76,11 @@ int main(int argc, const char **argv)
     // If a top-level binding file was specified, set configuration to use it.
     if (!OutputModuleName.empty())
         chimera::Configuration::GetInstance().SetOutputModuleName(OutputModuleName);
+
+    // Add top-level namespaces to the configuration.
+    if (NamespaceNames.size())
+        for (const std::string &name : NamespaceNames)
+            chimera::Configuration::GetInstance().AddInputNamespaceName(name);
 
     // Create tool that uses the command-line options.
     ClangTool Tool(OptionsParser.getCompilations(),


### PR DESCRIPTION
With this option, it is possible to generate simple bindings entirely without a configuration YAML file.

Closes #45.
