### PR TITLE
Added flag to control docs extraction.

### DIFF
--- a/src/chimera.cpp
+++ b/src/chimera.cpp
@@ -46,6 +46,11 @@ static cl::opt<bool> UseCMode(
     "use-c", cl::cat(ChimeraCategory),
     cl::desc("Parse input files as C instead of C++"));
 
+// Option for switching from C++ to C source.
+static cl::opt<bool> SuppressDocs(
+    "no-docs", cl::cat(ChimeraCategory),
+    cl::desc("Suppress the extraction of documentation from C++ comments"));
+
 // Add a footer to the help text.
 static cl::extrahelp MoreHelp(
     "\n"
@@ -74,6 +79,11 @@ int main(int argc, const char **argv)
     // Create tool that uses the command-line options.
     ClangTool Tool(OptionsParser.getCompilations(),
                    OptionsParser.getSourcePathList());
+
+    // Add or suppress clang documentation flag as specified.
+    Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(
+        SuppressDocs ? "-Wno-documentation" : "-Wdocumentation",
+        ArgumentInsertPosition::BEGIN));
 
     // Add the appropriate C/C++ language flag.
     Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(

--- a/test/bind_dart.sh
+++ b/test/bind_dart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-DART_INCLUDE="${HOME}/storage/dart-ws/devel/include"
+DART_INCLUDE="${HOME}/ws/devel/include"
 ARGS="-DBOOST_TEST_DYN_LINK -Wall -msse2 -fPIC -std=c++11 -O3 -DNDEBUG -I${DART_INCLUDE} -isystem /usr/include/eigen3 -isystem /opt/ros/indigo/include -isystem /usr/include/coin -isystem /home/mkoval/storage/chimera-ws/devel/lib/clang/3.8.0/include/"
 
 mkdir -p /tmp/dartpy
-../build/chimera -m dartpy -c ./test.yaml -o /tmp/dartpy "${DART_INCLUDE}/dart/dart.h" -- ${ARGS}
+chimera -m dartpy -n dart::dynamics -n dart::math -o /tmp/dartpy "${DART_INCLUDE}/dart/dart.h" -- ${ARGS}
 cp CMakeLists.txt /tmp/dartpy


### PR DESCRIPTION
This adds a new flag `-no-docs` to control the automatic addition
of the `-Wdocumentation/-Wno-documentation` flags to the internal
compiler arguments used in Chimera.

This avoids having to do comment parsing, or pass the non-standard
`-Wdocumentation` flag, when doing test compilations to figure out
the necessary flags with which to run chimera.

Closes #82
