### PR TITLE
Support for Clang 3.8 and above

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11 -Wno-unused-parameter")
 llvm_map_components_to_libnames(llvm_libs
   core
   irreader
+  ipo
   mcparser
   option
 )

--- a/src/chimera.cpp
+++ b/src/chimera.cpp
@@ -7,7 +7,6 @@
 #include <clang/Tooling/CommonOptionsParser.h>
 #include <clang/Tooling/Tooling.h>
 #include <clang/Tooling/ArgumentsAdjusters.h>
-#include <llvm/Config/config.h>
 #include <llvm/Support/CommandLine.h>
 #include <memory>
 #include <string>


### PR DESCRIPTION
These changes were necessary to get Chimera to build against Clang 4.0.0 on macOS. I believe this should: (1) not break backwards compatibility with Clang 3.6 and (2) should add support for the intermediate versions (i.e. 3.7, 3.8, and 3.9).

This may require some back-and-forth with Travis to make sure that it works on all those versions.