### PR TITLE
Add option whether build mstch or use installed one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ script:
   - mkdir build
   - cd build
   - cmake "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" "-DLLVM_DIR=${LLVM_DIR}" ..
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then cmake "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" "-DLLVM_DIR=${LLVM_DIR}" "-DCHIMERA_BUILD_MSTCH=ON" ..; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx"   ]; then cmake "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" "-DLLVM_DIR=${LLVM_DIR}" "-DCHIMERA_BUILD_MSTCH=OFF" ..; fi
   - make -j4
   - make test
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ project(chimera)
 cmake_minimum_required(VERSION 2.8)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/")
 
+option(CHIMERA_BUILD_MSTCH
+    "Build external/mstch instead of using installed mstch" TRUE)
+
 set(RUNTIME_INSTALL_DIR "bin")
 set(SHARE_INSTALL_DIR "share/${PROJECT_NAME}")
 
@@ -26,6 +29,10 @@ add_definitions(${YAMLCPP_DEFINITIONS})
 
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+
+if(NOT CHIMERA_BUILD_MSTCH)
+    find_package(mstch REQUIRED)
+endif()
 
 ## Set up glorious compiler options.
 if (NOT DEFINED CMAKE_BUILD_TYPE)
@@ -63,7 +70,9 @@ llvm_map_components_to_libnames(llvm_libs
 )
 
 # Build the external tools: Mustache and Cling.
-add_subdirectory(external/mstch)
+if(CHIMERA_BUILD_MSTCH)
+    add_subdirectory(external/mstch)
+endif()
 include_directories(${mstch_INCLUDE_DIR})
 
 add_subdirectory(external/cling)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/")
 
 option(CHIMERA_BUILD_MSTCH
-    "Build external/mstch instead of using installed mstch" TRUE)
+    "Build external/mstch instead of using installed mstch" ON)
 
 set(RUNTIME_INSTALL_DIR "bin")
 set(SHARE_INSTALL_DIR "share/${PROJECT_NAME}")

--- a/ci/install_macos.sh
+++ b/ci/install_macos.sh
@@ -93,3 +93,4 @@ export LLVM_DIR
 brew install boost
 brew install "${LLVM_PACKAGE}"
 brew install yaml-cpp --with-static-lib
+brew install mstch


### PR DESCRIPTION
I realized that Homebrew contains [mstch package](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mstch.rb) while Ubuntu doesn't, and installing Chimera with the internal mstch conflicts when mstch is installed on macOS.

This PR adds an option whether build the internal mstch or use installed mstch. The option is ON (build internal mstch) so that the default behavior is the same as before. We might want to set the option OFF when building on macOS to avoid the confliction.

The [Homebrew formula for Chimera](https://github.com/personalrobotics/homebrew-tap/blob/master/Formula/chimera.rb) will be updated accordingly once this is merged.