### PR TITLE
Added fix for HTML escaping.

### DIFF
--- a/include/chimera/mstch.h
+++ b/include/chimera/mstch.h
@@ -31,6 +31,18 @@ namespace mstch
 ::mstch::node wrapYAMLNode(const YAML::Node &node);
 
 /**
+ * Custom escape function that disables HTML escaping on mstch output.
+ *
+ * This is not desirable in chimera because many C++ types include characters
+ * that can be accidentally escaped, such as `<>` and `&`.
+ *
+ * See: https://github.com/no1msd/mstch#custom-escape-function
+ */
+::mstch::config::escape = [](const std::string& str) -> std::string {
+  return str;
+};
+
+/**
  * Base mstch wrapper for Clang declarations.
  */
 template<typename T>
@@ -184,7 +196,7 @@ public:
     ::mstch::node constructors();
     ::mstch::node methods();
     ::mstch::node staticMethods();
-    
+
     ::mstch::node fields();
     ::mstch::node staticFields();
 

--- a/src/boost_python_mstch.cpp
+++ b/src/boost_python_mstch.cpp
@@ -6,23 +6,23 @@ const std::string CLASS_BINDING_CPP = R"(
  * Automatically generated class binding for '{{class.name}}'.
  * Generated on {{date}}.
  */
-{{{header}}}
+{{header}}
 {{#includes}}
-#include <{{{.}}}>
+#include <{{.}}>
 {{/includes}}
-{{{precontent}}}
+{{precontent}}
 
 class {{class.mangled_name}}
 {
-    {{{prebody}}}
+    {{prebody}}
     /* constructors */
     /* methods */
     /* static methods */
     /* fields */
-    {{{postbody}}}
+    {{postbody}}
 }
-{{{postcontent}}}
-{{{footer}}}
+{{postcontent}}
+{{footer}}
 )";
 
 const std::string ENUM_BINDING_CPP = R"(
@@ -57,21 +57,21 @@ const std::string MODULE_CPP = R"(
  * >>> import {{module.name}}
  *
  */
-{{{header}}}
+{{header}}
 {{#includes}}
-#include <{{{.}}}>
+#include <{{.}}>
 {{/includes}}
-{{{precontent}}}
+{{precontent}}
 
 BOOST_PYTHON({{module.name}})
 {
-  {{{prebody}}}
+  {{prebody}}
   {{#module.bindings}}
   {{.}}();
   {{/module.bindings}}
-  {{{postbody}}}
+  {{postbody}}
 }
-{{{postcontent}}}
-{{{footer}}}
+{{postcontent}}
+{{footer}}
 
 )";

--- a/test/templates/cxx_record.mstch.cpp
+++ b/test/templates/cxx_record.mstch.cpp
@@ -1,23 +1,23 @@
 /**
  * Automatically generated Boost.Python class binding for '{{class.name}}'.
  */
-{{{header}}}
+{{header}}
 {{#includes}}
-#include <{{{.}}}>
+#include <{{.}}>
 {{/includes}}
-{{{precontent}}}
+{{precontent}}
 
 void {{class.mangled_name}}
 {
-    {{{prebody}}}
-    ::boost::python::class_<{{{class.qualified_name}}}{{^class.is_copyable}},
+    {{prebody}}
+    ::boost::python::class_<{{class.qualified_name}}{{^class.is_copyable}},
         ::boost::noncopyable{{/class.is_copyable}}{{#class.bases?}},
-        ::boost::python::bases<{{#class.bases}}{{{qualified_name}}}{{^last}},
+        ::boost::python::bases<{{#class.bases}}{{qualified_name}}{{^last}},
                                {{/last}}{{/class.bases}}>{{/class.bases?}}>("{{class.name}}", boost::python::no_init)
 
     /* constructors */
     {{#class.constructors}}
-    .def(::boost::python::init<{{#params}}{{{type}}}{{^last}},
+    .def(::boost::python::init<{{#params}}{{type}}{{^last}},
                                {{/last}}{{/params}}>
             ({{#params?}}({{#params}}::boost::python::arg("{{name}}"){{^last}},
               {{/last}}{{/params}}){{/params?}}))
@@ -26,10 +26,10 @@ void {{class.mangled_name}}
     /* methods */
     {{#class.methods}}
     .def("{{name}}",
-        static_cast<{{{type}}}>(&{{qualified_name}}){{#params?}},
+        static_cast<{{type}}>(&{{qualified_name}}){{#params?}},
             ({{#params}}::boost::python::arg("{{name}}"){{^last}},
              {{/last}}{{/params}}){{/params?}}{{#return_value_policy}},
-            ::boost::python::return_value_policy<{{{.}}}>(){{/return_value_policy}}){{#is_static}}
+            ::boost::python::return_value_policy<{{.}}>(){{/return_value_policy}}){{#is_static}}
     .staticmethod("{{name}}"){{/is_static}}
     {{/class.methods}}
 
@@ -39,7 +39,7 @@ void {{class.mangled_name}}
         &{{qualified_name}})
     {{/class.fields}}
 
-    {{{postbody}}};
+    {{postbody}};
 }
-{{{postcontent}}}
-{{{footer}}}
+{{postcontent}}
+{{footer}}

--- a/test/templates/enum.mstch.cpp
+++ b/test/templates/enum.mstch.cpp
@@ -1,18 +1,18 @@
 /**
  * Automatically generated Boost.Python enum binding for '{{enum.name}}'.
  */
-{{{header}}}
+{{header}}
 {{#includes}}
-#include <{{{.}}}>
+#include <{{.}}>
 {{/includes}}
-{{{precontent}}}
+{{precontent}}
 
 void {{enum.mangled_name}}()
 {
-    {{{prebody}}}
+    {{prebody}}
     ::boost::python::enum_<{{enum.qualified_name}}>("{{enum.name}}"){{#enum.values}}
         .value("{{name}}", {{qualified_name}}){{/enum.values}}
-    {{{postbody}}};
+    {{postbody}};
 }
-{{{postcontent}}}
-{{{footer}}}
+{{postcontent}}
+{{footer}}

--- a/test/templates/function.mstch.cpp
+++ b/test/templates/function.mstch.cpp
@@ -1,20 +1,20 @@
 /**
  * Automatically generated Boost.Python function binding for '{{function.name}}'.
  */
-{{{header}}}
+{{header}}
 {{#includes}}
-#include <{{{.}}}>
+#include <{{.}}>
 {{/includes}}
-{{{precontent}}}
+{{precontent}}
 
 void {{function.mangled_name}}()
 {
-    {{{prebody}}}
+    {{prebody}}
     boost::python::def("{{function.name}}",
-        static_cast<{{{function.type}}}>(&{{function.qualified_name}}),
+        static_cast<{{function.type}}>(&{{function.qualified_name}}),
             ({{#function.params}}::boost::python::arg("{{name}}"){{^last}},
              {{last}}{{/function.params}}));
-    {{{postbody}}}
+    {{postbody}}
 }
-{{{postcontent}}}
-{{{footer}}}
+{{postcontent}}
+{{footer}}

--- a/test/templates/module.mstch.cpp
+++ b/test/templates/module.mstch.cpp
@@ -7,21 +7,21 @@
  * >>> import {{module.name}}
  *
  */
-{{{header}}}
+{{header}}
 {{#includes}}
-#include <{{{.}}}>
+#include <{{.}}>
 {{/includes}}
-{{{precontent}}}
+{{precontent}}
 
 BOOST_PYTHON({{module.name}})
 {
-  {{{prebody}}}
+  {{prebody}}
   {{#module.bindings}}
   void {{.}}();
   {{.}}();
 
   {{/module.bindings}}
-  {{{postbody}}}
+  {{postbody}}
 }
-{{{postcontent}}}
-{{{footer}}}
+{{postcontent}}
+{{footer}}

--- a/test/templates/variable.mstch.cpp
+++ b/test/templates/variable.mstch.cpp
@@ -1,17 +1,17 @@
 /**
  * Automatically generated Boost.Python global variable binding for '{{variable.name}}'.
  */
-{{{header}}}
+{{header}}
 {{#includes}}
-#include <{{{.}}}>
+#include <{{.}}>
 {{/includes}}
-{{{precontent}}}
+{{precontent}}
 
 void {{variable.mangled_name}}
 {
-    {{{prebody}}}
+    {{prebody}}
     ::boost::python::scope().attr("{{variable.name}}") = {{variable.qualified_name}};
-    {{{postbody}}}
+    {{postbody}}
 }
-{{{postcontent}}}
-{{{footer}}}
+{{postcontent}}
+{{footer}}


### PR DESCRIPTION
This commit adds a custom escaping function to the mstch namespace
that disables all HTML escaping.  Since HTML escaping heavily
interferes with generation of valid C++ type declarations, this
was causing numerous issues in code generation.

As a side effect, the _unescaped_ template include operator for
mstch, `{{{ }}}`, should no longer be necessary, so I have
removed it from all instances of templates in the source tree.

Closes #104.