### PR TITLE
Converts mstch build to an ExternalProject.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,12 @@ llvm_map_components_to_libnames(llvm_libs
 )
 
 # Build the external tools: Mustache and Cling.
-add_subdirectory(external/mstch)
-include_directories(${mstch_INCLUDE_DIR})
-
-add_subdirectory(external/cling)
+add_subdirectory(external)
+# TODO: The following directives are no longer necessary in CMake 3.0+
+get_target_property(cling_utils_INCLUDE_DIR cling_utils INTERFACE_INCLUDE_DIRECTORIES)
 include_directories(${cling_utils_INCLUDE_DIR})
+get_target_property(mstch_INCLUDE_DIR mstch INTERFACE_INCLUDE_DIRECTORIES)
+include_directories(${mstch_INCLUDE_DIR})
 
 # Build the main chimera executable.
 add_executable("${PROJECT_NAME}"

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -26,4 +26,3 @@ set_target_properties(mstch PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${mstch_INCLUDE_DIR}"
     IMPORTED_LOCATION "${mstch_LIBRARY}"
 )
-message("JUST ADDED TARGET MSTCH")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Build a small subcomponent of cling using a custom `CMakeLists.txt`.
+# This `CMakeLists.txt` has no install step so we can directly include it.
+add_subdirectory(cling)
+
+# Build mstch as *only* a static library for linking into chimera.
+# Uses ExternalProject to prevent install steps from propagating to chimera.
+include(ExternalProject)
+ExternalProject_Add(mstch_EXTERNAL
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mstch"
+    DOWNLOAD_COMMAND ""
+    INSTALL_COMMAND ""
+    CMAKE_GENERATOR "${CMAKE_GENERATOR}"
+)
+
+# Retrieve properties of the ExternalProject to find build artifacts.
+ExternalProject_Get_Property(mstch_EXTERNAL SOURCE_DIR BINARY_DIR)
+set(mstch_INCLUDE_DIR "${SOURCE_DIR}/include")
+set(mstch_LIBRARY "${BINARY_DIR}/src/${CMAKE_STATIC_LIBRARY_PREFIX}mstch${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+# Create an IMPORTED target so that CMake can propagate the build properties of
+# this ExternalProject to dependent targets.
+# (Note: This target must be GLOBAL as per: http://stackoverflow.com/a/26315239)
+add_library(mstch STATIC IMPORTED GLOBAL)
+add_dependencies(mstch mstch_EXTERNAL)
+set_target_properties(mstch PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${mstch_INCLUDE_DIR}"
+    IMPORTED_LOCATION "${mstch_LIBRARY}"
+)
+message("JUST ADDED TARGET MSTCH")

--- a/external/cling/CMakeLists.txt
+++ b/external/cling/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Compile a small subset of cling::utils.
 set(cling_utils_INCLUDE_DIR
   "${CMAKE_CURRENT_SOURCE_DIR}/include"
-  CACHE STRING
-  "cling utils include directory"
 )
 
 include_directories(
@@ -16,4 +14,8 @@ add_library(cling_utils STATIC
 target_link_libraries(cling_utils
   ${CLANG_LIBS}
   ${llvm_libs}
+)
+
+set_target_properties(cling_utils PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${cling_utils_INCLUDE_DIR}"
 )


### PR DESCRIPTION
Previously, mstch was built in-source using an `add_subdirectory()` directive.  This caused its `EXPORT` and `INSTALL` directives to be forwarded into chimera's own install step.

This PR changes the build process to use an `ExternalProject` to generate the static `mstch` library, which prevents this forwarding.

Closes #129.