### PR TITLE
Staged `sources.txt` generation in CMake binding helpers.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CTest)
 
-set(chimera_DIR "${PROJECT_BINARY_DIR}")
+set(chimera_EXECUTABLE $<TARGET_FILE:chimera>)
 include(chimeraFunctions)
 
 add_chimera_binding(


### PR DESCRIPTION
**This PR is included in #135, so optionally we can just review and merge that one.**

Previously, `sources.txt` was directly piped from the output of chimera, but was not cleared or invalidated if the command did not complete successfully, leading to subsequent build steps skipping the regeneration of sources.

This PR changes the `add_custom_command()` directive to stage the output of chimera to a temp file first, which is moved into a final location after the success of the generation command.  This prevents incomplete or invalid `sources.txt` from being used by subsequent build steps.

As a side effect of this PR, I discovered a bug in the unit test runner `CMakeLists.txt` that was leading to the test practically always succeeding because it did not have the `chimeraExecutable` variable set and somehow managed to run a very ill defined bash command that always succeeded.

Closes #114.