### PR TITLE
Modified CMake to use newer directives.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(SYSTEM ${CLANG_INCLUDE_DIRS})
 add_definitions(${CLANG_DEFINITIONS})
 
 set(YAMLCPP_STATIC_LIBRARY ON CACHE BOOL
-    "If true, try to find static yaml-cpp library first instead of dynamic.")
+  "If true, try to find static yaml-cpp library first instead of dynamic.")
 find_package(YamlCpp REQUIRED)
 include_directories(SYSTEM ${YAMLCPP_INCLUDE_DIRS})
 add_definitions(${YAMLCPP_DEFINITIONS})
@@ -29,22 +29,23 @@ include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 ## Set up default compiler options.
 if (NOT DEFINED CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE RelWithDebugInfo)
+  set(CMAKE_BUILD_TYPE RelWithDebugInfo)
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set(CMAKE_COMPILER_IS_CLANGCXX TRUE)
+  set(CMAKE_COMPILER_IS_CLANGCXX TRUE)
 endif()
 
 if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
-    if (CMAKE_COMPILER_IS_CLANGCXX)
-        add_definitions("-fcolor-diagnostics")
-    endif()
+  if (CMAKE_COMPILER_IS_CLANGCXX)
+    add_definitions("-fcolor-diagnostics")
+  endif()
 endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGCXX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wall -Wstrict-aliasing=2")
+  add_compile_options("-Wextra" "-Wall" "-Wstrict-aliasing=2")
 endif()
+add_compile_options("-Wno-unused-parameter")
 
 ###########
 ## BUILD ##
@@ -75,8 +76,7 @@ add_executable("${PROJECT_NAME}"
 )
 
 target_compile_options("${PROJECT_NAME}"
-  PUBLIC "--std=c++11"
-  PRIVATE "-Wno-unused-parameter"
+  PUBLIC "-std=c++11"
 )
 
 target_include_directories("${PROJECT_NAME}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(chimera)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/")
 
 set(RUNTIME_INSTALL_DIR "bin")
@@ -27,7 +27,7 @@ add_definitions(${YAMLCPP_DEFINITIONS})
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
-## Set up glorious compiler options.
+## Set up default compiler options.
 if (NOT DEFINED CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebugInfo)
 endif()
@@ -44,14 +44,11 @@ endif()
 
 if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wall -Wstrict-aliasing=2")
-    # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -fno-rtti -fno-exceptions")
 endif()
 
 ###########
 ## BUILD ##
 ###########
-include_directories("${CMAKE_CURRENT_LIST_DIR}/include")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11 -Wno-unused-parameter")
 
 ## Use LLVM CMake macro to collate and order link libraries.
 llvm_map_components_to_libnames(llvm_libs
@@ -64,11 +61,6 @@ llvm_map_components_to_libnames(llvm_libs
 
 # Build the external tools: Mustache and Cling.
 add_subdirectory(external)
-# TODO: The following directives are no longer necessary in CMake 3.0+
-get_target_property(cling_utils_INCLUDE_DIR cling_utils INTERFACE_INCLUDE_DIRECTORIES)
-include_directories(${cling_utils_INCLUDE_DIR})
-get_target_property(mstch_INCLUDE_DIR mstch INTERFACE_INCLUDE_DIRECTORIES)
-include_directories(${mstch_INCLUDE_DIR})
 
 # Build the main chimera executable.
 add_executable("${PROJECT_NAME}"
@@ -80,6 +72,15 @@ add_executable("${PROJECT_NAME}"
   src/visitor.cpp
   src/util.cpp
   src/mstch.cpp
+)
+
+target_compile_options("${PROJECT_NAME}"
+  PUBLIC "--std=c++11"
+  PRIVATE "-Wno-unused-parameter"
+)
+
+target_include_directories("${PROJECT_NAME}"
+  PRIVATE "${CMAKE_CURRENT_LIST_DIR}/include"
 )
 
 target_link_libraries("${PROJECT_NAME}"

--- a/external/cling/CMakeLists.txt
+++ b/external/cling/CMakeLists.txt
@@ -1,14 +1,10 @@
 # Compile a small subset of cling::utils.
-set(cling_utils_INCLUDE_DIR
-  "${CMAKE_CURRENT_SOURCE_DIR}/include"
-)
-
-include_directories(
-  ${cling_utils_INCLUDE_DIR}
-)
-
 add_library(cling_utils STATIC
   src/cling_utils_AST.cpp
+)
+
+target_compile_options(cling_utils
+  PUBLIC "--std=c++11"
 )
 
 target_link_libraries(cling_utils
@@ -16,6 +12,6 @@ target_link_libraries(cling_utils
   ${llvm_libs}
 )
 
-set_target_properties(cling_utils PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${cling_utils_INCLUDE_DIR}"
+target_include_directories(cling_utils
+  PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )

--- a/external/cling/CMakeLists.txt
+++ b/external/cling/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(cling_utils STATIC
 )
 
 target_compile_options(cling_utils
-  PUBLIC "--std=c++11"
+  PUBLIC "-std=c++11"
 )
 
 target_link_libraries(cling_utils

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,18 +14,20 @@ add_chimera_binding(
 )
 
 target_include_directories(test_binding SYSTEM
-  PRIVATE ${Boost_INCLUDE_DIRS}
-  PRIVATE ${PYTHON_INCLUDE_DIRS}
+  PRIVATE
+    ${Boost_INCLUDE_DIRS}
+    ${PYTHON_INCLUDE_DIRS}
 )
 
 target_link_libraries(test_binding
-  ${Boost_PYTHON_LIBRARIES}
-  ${PYTHON_LIBRARIES}
+  PRIVATE
+    ${Boost_PYTHON_LIBRARY}
+    ${PYTHON_LIBRARIES}
 )
 
 add_test(
-    NAME ctest_build_binding
-    COMMAND "${CMAKE_COMMAND}"
-        --build ${CMAKE_BINARY_DIR}
-        --target test_binding
+  NAME ctest_build_binding
+  COMMAND "${CMAKE_COMMAND}"
+    --build ${CMAKE_BINARY_DIR}
+    --target test_binding
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,21 +6,23 @@ include(chimeraFunctions)
 find_package(Boost REQUIRED COMPONENTS python)
 find_package(PythonLibs REQUIRED)
 
-include_directories(SYSTEM
-  ${Boost_INCLUDE_DIRS}
-  ${PYTHON_INCLUDE_DIRS}
-)
-
 add_chimera_binding(
   EXCLUDE_FROM_ALL
   TARGET test_binding
   SOURCES dart-example.cpp
   NAMESPACES dart
 )
+
+target_include_directories(test_binding SYSTEM
+  PRIVATE ${Boost_INCLUDE_DIRS}
+  PRIVATE ${PYTHON_INCLUDE_DIRS}
+)
+
 target_link_libraries(test_binding
   ${Boost_PYTHON_LIBRARIES}
   ${PYTHON_LIBRARIES}
 )
+
 add_test(
     NAME ctest_build_binding
     COMMAND "${CMAKE_COMMAND}"


### PR DESCRIPTION
This PR updates the CMakeLists.txt to use newer `target_` directives for includes and compile options, which removes some of the cruft associated with inheriting these properties.

The required version of CMake has been updated to 2.8.12 to make use of these newer features. This should be available on all targeted platforms (and specifically, Ubuntu 14.04).

Closes #141 