### PR TITLE
Add error message when expected scalar is not found.

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -516,7 +516,11 @@ std::string chimera::CompiledConfiguration::Lookup(const YAML::Node &node) const
 {
     // If the node is not scalar, we cannot load it, so return the default.
     if (!node.IsScalar())
-        return "";
+    {
+        std::cerr << "Unable to parse expected scalar or file source."
+                  << std::endl;
+        exit(-2);
+    }
 
     // If the node type tag is "file" then load the contents of a file.
     if (node.Tag() == "file")
@@ -545,7 +549,7 @@ std::string chimera::CompiledConfiguration::Lookup(const YAML::Node &node) const
         std::ifstream source(source_path);
         if (source.fail())
         {
-            std::cerr << "Warning: Failed to open source '"
+            std::cerr << "Failed to open source '"
                       << source_path << "': " << strerror(errno) << std::endl;
             exit(-5);
         }


### PR DESCRIPTION
The `chimera::CompiledConfiguration::Lookup()` function is intended to handle either scalar values or (when a `file` tag is specified) a path to a file on disk.

This commit throws an error when neither of those two values is found in the node provided to `Lookup()`, instead of the previous behavior of simply returning an empty string instead.

This prevents configuration parsing issues from being masked by other errors due to the empty string.

Closes #160 