### PR TITLE
Fixed a typo preventing file source loading.

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -518,8 +518,8 @@ std::string chimera::CompiledConfiguration::Lookup(const YAML::Node &node) const
     if (!node.IsScalar())
         return "";
 
-    // If the node type tag is "file" then load the contents of a file.
-    if (node.Tag() == "file")
+    // If the node type tag is "!file" then load the contents of a file.
+    if (node.Tag() == "!file")
     {
         // Get reference to path to configuration file itself.
         const std::string &config_path = parent_.GetConfigFilename();


### PR DESCRIPTION
This commit fixes a typo in tag specification that was preventing correct parsing of the `!file` tag type to allow file paths to be specified as values in certain values in the configuration YAML.