### PR TITLE
Fix build error on macOS + llvm-4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ matrix:
 #      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
     - os: osx
       compiler: clang
-      env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4.0
+      env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4
     - os: osx
       compiler: clang
-      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4.0
+      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4
 
 install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then . ci/install_linux.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,24 @@ matrix:
       compiler: clang
       env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.6
 # Disabled for macOS + llvm-3.7 (see https://github.com/personalrobotics/chimera/issues/153)
-#    - os: osx
-#      compiler: clang
-#      env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
-#    - os: osx
-#      compiler: clang
-#      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
+   - os: osx
+     compiler: clang
+     env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
+   - os: osx
+     compiler: clang
+     env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
     - os: osx
       compiler: clang
       env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4.0
     - os: osx
       compiler: clang
       env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4.0
+    - os: osx
+      compiler: clang
+      env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=5.0
+    - os: osx
+      compiler: clang
+      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=5.0
 
 install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then . ci/install_linux.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ matrix:
 #      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
     - os: osx
       compiler: clang
-      env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4
+      env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4.0
     - os: osx
       compiler: clang
-      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4
+      env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4.0
 
 install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then . ci/install_linux.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ matrix:
       compiler: clang
       env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.6
 # Disabled for macOS + llvm-3.7 (see https://github.com/personalrobotics/chimera/issues/153)
-   - os: osx
-     compiler: clang
-     env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
-   - os: osx
-     compiler: clang
-     env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
+    # - os: osx
+    #   compiler: clang
+    #   env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
+    # - os: osx
+    #   compiler: clang
+    #   env: BUILD_TYPE=Release CODECOV=OFF COMPILER=CLANG LLVM_VERSION=3.7
     - os: osx
       compiler: clang
       env: BUILD_TYPE=Debug CODECOV=OFF COMPILER=CLANG LLVM_VERSION=4.0

--- a/ci/install_macos.sh
+++ b/ci/install_macos.sh
@@ -73,10 +73,11 @@ if check_version "${LLVM_VERSION}" '=' "${LLVM_VERSION_LATEST}"; then
 else
   if check_version "${LLVM_VERSION}" '=' "4.0"; then
     LLVM_PACKAGE="llvm@4"
+    LLVM_INSTALL_PREFIX="llvm@4"
   else
     LLVM_PACKAGE="llvm@${LLVM_VERSION}"
+    LLVM_INSTALL_PREFIX="llvm-${LLVM_VERSION}"
   fi
-  LLVM_INSTALL_PREFIX="llvm-${LLVM_VERSION}"
 
   if ! brew info "${LLVM_PACKAGE}" > /dev/null 2> /dev/null; then
     echo "error: There is no package Homebrew package named '${LLVM_PACKAGE}'"\

--- a/ci/install_macos.sh
+++ b/ci/install_macos.sh
@@ -73,7 +73,10 @@ if check_version "${LLVM_VERSION}" '=' "${LLVM_VERSION_LATEST}"; then
 else
   if check_version "${LLVM_VERSION}" '=' "4.0"; then
     LLVM_PACKAGE="llvm@4"
-    LLVM_INSTALL_PREFIX="llvm@4"
+    LLVM_INSTALL_PREFIX="llvm"
+  elif check_version "${LLVM_VERSION}" '=' "3.9"; then
+    LLVM_PACKAGE="llvm@${LLVM_VERSION}"
+    LLVM_INSTALL_PREFIX='llvm'
   else
     LLVM_PACKAGE="llvm@${LLVM_VERSION}"
     LLVM_INSTALL_PREFIX="llvm-${LLVM_VERSION}"

--- a/ci/install_macos.sh
+++ b/ci/install_macos.sh
@@ -71,7 +71,11 @@ if check_version "${LLVM_VERSION}" '=' "${LLVM_VERSION_LATEST}"; then
   LLVM_PACKAGE="${LLVM_PACKAGE_LATEST}"
   LLVM_INSTALL_PREFIX='llvm'
 else
-  LLVM_PACKAGE="llvm@${LLVM_VERSION}"
+  if check_version "${LLVM_VERSION}" '=' "4.0"; then
+    LLVM_PACKAGE="llvm@4"
+  else
+    LLVM_PACKAGE="llvm@${LLVM_VERSION}"
+  fi
   LLVM_INSTALL_PREFIX="llvm-${LLVM_VERSION}"
 
   if ! brew info "${LLVM_PACKAGE}" > /dev/null 2> /dev/null; then


### PR DESCRIPTION
The homebrew package name of llvm-4.0 was changed from `llvm@4.0` to `llvm@4` for some reason. This PR adjusts the llvm version inference logic in `install_macos.sh` accordingly.

Resolves #162