### PR TITLE
Added ordering to traversed namespaces in configuration.

### DIFF
--- a/include/chimera/configuration.h
+++ b/include/chimera/configuration.h
@@ -21,6 +21,7 @@ class CXXRecord;
 class Enum;
 class Function;
 class Variable;
+class Namespace;
 
 } // mstch
 } // chimera
@@ -211,7 +212,8 @@ protected:
     std::set<const clang::NamespaceDecl*> namespaces_;
 
     std::vector<std::string> binding_names_;
-    std::set<const clang::NamespaceDecl*> binding_namespaces_;
+    std::vector<std::shared_ptr<chimera::mstch::Namespace>> binding_namespaces_;
+    std::set<const clang::NamespaceDecl*> binding_namespace_decls_;
 
     friend class Configuration;
 };

--- a/src/chimera.cpp
+++ b/src/chimera.cpp
@@ -116,7 +116,6 @@ int main(int argc, const char **argv)
         "-I/usr/lib/llvm-" STR(LLVM_VERSION_MAJOR) "." STR(LLVM_VERSION_MINOR)
         "/lib/clang/" LLVM_VERSION_STRING "/include", ArgumentInsertPosition::END));
 
-
     // Run the instantiated tool on the Chimera frontend.
     return Tool.run(newFrontendActionFactory<chimera::FrontendAction>().get());
 }

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -420,10 +420,11 @@ void
 chimera::CompiledConfiguration::AddTraversedNamespace(const clang::NamespaceDecl* decl)
 {
     // We need to preserve the order of the traversed namespace declarations,
-    // because the consumer will traverse them in a hierarchical order.  So we
-    // use a set to de-duplicate the namespaces using their canonical decl
-    // pointers, then insert their renderable proxy into a vector which will
-    // preserve their insertion order.
+    // as the ASTConsumer traverses them in a hierarchical order.
+    //
+    // We first use a set to de-duplicate the namespaces using their canonical
+    // decl pointers, then insert the renderable proxy of new namespaces into
+    // a vector which will preserve their order during Render().
     const auto result = binding_namespace_decls_.insert(decl->getCanonicalDecl());
     if (result.second)
     {

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -424,6 +424,16 @@ chimera::CompiledConfiguration::~CompiledConfiguration()
 void
 chimera::CompiledConfiguration::AddTraversedNamespace(const clang::NamespaceDecl* decl)
 {
+    // If there is an enclosing namespace, ensure that it will be traversed
+    // before the child namespace when the binding is generated.
+    const auto *enclosing_ns_context = decl->getEnclosingNamespaceContext();
+    const auto *enclosing_ns_decl = llvm::dyn_cast_or_null<NamespaceDecl>(enclosing_ns_context);
+    if (enclosing_ns_decl)
+    {
+        AddTraversedNamespace(enclosing_ns_decl);
+    }
+
+    // Add the canonical declaration of this namespace to the traversed set.
     binding_namespaces_.insert(decl->getCanonicalDecl());
 }
 


### PR DESCRIPTION
This addresses #165 where parent namespace declarations were being provided to the binding template
from `CompiledConfiguration` in an order that could not be used to construct namespace templates hierarchically (children were sometimes traversed before parents).

The underlying problem was that although the `ASTConsumer` guaranteed a hierarchical traversal of the `NamespaceDecls`, the traversed namespaces were being stored in a `std::set`, which re-ordered them arbitrarily by their canonical decl pointers.  This PR adds a `std::vector` which preserves the order of the namespaces for rendering, while still checking them against a `std::set` for de-duplication.

----

Closes #165