### PR TITLE
Disable cling_utils_AST.h functions that are incompatible with LLVM 6

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-set -x
-# Disable e option for now
+set -ex
 
 mkdir build
 cd build

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -ex
+set -x
+# Disable e option for now; this always fails for some unknown reasons
 
 mkdir build
 cd build

--- a/external/cling/include/cling_utils_AST.h
+++ b/external/cling/include/cling_utils_AST.h
@@ -75,10 +75,11 @@ namespace utils {
     ///                           synthesis of the DeclRefExpr.
     ///\returns 0 if the operation wasn't successful.
     ///
-    clang::Expr* GetOrCreateLastExpr(clang::FunctionDecl* FD,
-                                     int* FoundAt = 0,
-                                     bool omitDeclStmts = true,
-                                     clang::Sema* S = 0);
+    // NOTE(JS): This function disabled because it attempts to use a private member of LLVM 6
+    // clang::Expr* GetOrCreateLastExpr(clang::FunctionDecl* FD,
+    //                                  int* FoundAt = 0,
+    //                                  bool omitDeclStmts = true,
+    //                                  clang::Sema* S = 0);
 
     ///\brief Return true if the class or template is declared directly in the
     /// std namespace (modulo inline namespace).

--- a/external/cling/include/cling_utils_AST.h
+++ b/external/cling/include/cling_utils_AST.h
@@ -207,9 +207,10 @@ namespace utils {
     ///                    TranslationUnitDecl is used.
     ///\returns the found result if single, -1 if multiple or 0 if not found.
     ///
-    clang::NamedDecl* Named(clang::Sema* S,
-                            llvm::StringRef Name,
-                            const clang::DeclContext* Within = 0);
+    // NOTE(JS): This function disabled because it attempts to use a private member of LLVM 6
+    // clang::NamedDecl* Named(clang::Sema* S,
+    //                         llvm::StringRef Name,
+    //                         const clang::DeclContext* Within = 0);
 
     ///\brief Quick lookup for a single named declaration in a given
     /// declaration context.
@@ -220,9 +221,10 @@ namespace utils {
     ///                    TranslationUnitDecl is used.
     ///\returns the found result if single, -1 if multiple or 0 if not found.
     ///
-    clang::NamedDecl* Named(clang::Sema* S,
-                            const char* Name,
-                            const clang::DeclContext* Within = 0);
+    // NOTE(JS): This function disabled because it attempts to use a private member of LLVM 6
+    // clang::NamedDecl* Named(clang::Sema* S,
+    //                         const char* Name,
+    //                         const clang::DeclContext* Within = 0);
 
     ///\brief Quick lookup for a single namespace declaration in a given
     /// declaration context.
@@ -234,9 +236,10 @@ namespace utils {
     ///                    TranslationUnitDecl is used.
     ///\returns the found result if single, -1 if multiple or 0 if not found.
     ///
-    clang::NamedDecl* Named(clang::Sema* S,
-                            const clang::DeclarationName& Name,
-                            const clang::DeclContext* Within = 0);
+    // NOTE(JS): This function disabled because it attempts to use a private member of LLVM 6
+    // clang::NamedDecl* Named(clang::Sema* S,
+    //                         const clang::DeclarationName& Name,
+    //                         const clang::DeclContext* Within = 0);
 
   }
 

--- a/external/cling/src/cling_utils_AST.cpp
+++ b/external/cling/src/cling_utils_AST.cpp
@@ -108,68 +108,68 @@ namespace utils {
     RawStr.flush();
   }
 
-  Expr* Analyze::GetOrCreateLastExpr(FunctionDecl* FD,
-                                     int* FoundAt /*=0*/,
-                                     bool omitDeclStmts /*=true*/,
-                                     Sema* S /*=0*/) {
-    assert(FD && "We need a function declaration!");
-    assert((omitDeclStmts || S)
-           && "Sema needs to be set when omitDeclStmts is false");
-    if (FoundAt)
-      *FoundAt = -1;
+  // Expr* Analyze::GetOrCreateLastExpr(FunctionDecl* FD,
+  //                                    int* FoundAt /*=0*/,
+  //                                    bool omitDeclStmts /*=true*/,
+  //                                    Sema* S /*=0*/) {
+  //   assert(FD && "We need a function declaration!");
+  //   assert((omitDeclStmts || S)
+  //          && "Sema needs to be set when omitDeclStmts is false");
+  //   if (FoundAt)
+  //     *FoundAt = -1;
 
-    Expr* result = 0;
-    if (CompoundStmt* CS = dyn_cast<CompoundStmt>(FD->getBody())) {
-      ArrayRef<Stmt*> Stmts
-        = llvm::makeArrayRef(CS->body_begin(), CS->size());
-      int indexOfLastExpr = Stmts.size();
-      while(indexOfLastExpr--) {
-        if (!isa<NullStmt>(Stmts[indexOfLastExpr]))
-          break;
-      }
+  //   Expr* result = 0;
+  //   if (CompoundStmt* CS = dyn_cast<CompoundStmt>(FD->getBody())) {
+  //     ArrayRef<Stmt*> Stmts
+  //       = llvm::makeArrayRef(CS->body_begin(), CS->size());
+  //     int indexOfLastExpr = Stmts.size();
+  //     while(indexOfLastExpr--) {
+  //       if (!isa<NullStmt>(Stmts[indexOfLastExpr]))
+  //         break;
+  //     }
 
-      if (FoundAt)
-        *FoundAt = indexOfLastExpr;
+  //     if (FoundAt)
+  //       *FoundAt = indexOfLastExpr;
 
-      if (indexOfLastExpr < 0)
-        return 0;
+  //     if (indexOfLastExpr < 0)
+  //       return 0;
 
-      if ( (result = dyn_cast<Expr>(Stmts[indexOfLastExpr])) )
-        return result;
-      if (!omitDeclStmts)
-        if (DeclStmt* DS = dyn_cast<DeclStmt>(Stmts[indexOfLastExpr])) {
-          std::vector<Stmt*> newBody = Stmts.vec();
-          for (DeclStmt::reverse_decl_iterator I = DS->decl_rbegin(),
-                 E = DS->decl_rend(); I != E; ++I) {
-            if (VarDecl* VD = dyn_cast<VarDecl>(*I)) {
-              // Change the void function's return type
-              // We can't PushDeclContext, because we don't have scope.
-              Sema::ContextRAII pushedDC(*S, FD);
+  //     if ( (result = dyn_cast<Expr>(Stmts[indexOfLastExpr])) )
+  //       return result;
+  //     if (!omitDeclStmts)
+  //       if (DeclStmt* DS = dyn_cast<DeclStmt>(Stmts[indexOfLastExpr])) {
+  //         std::vector<Stmt*> newBody = Stmts.vec();
+  //         for (DeclStmt::reverse_decl_iterator I = DS->decl_rbegin(),
+  //                E = DS->decl_rend(); I != E; ++I) {
+  //           if (VarDecl* VD = dyn_cast<VarDecl>(*I)) {
+  //             // Change the void function's return type
+  //             // We can't PushDeclContext, because we don't have scope.
+  //             Sema::ContextRAII pushedDC(*S, FD);
 
-              QualType VDTy = VD->getType().getNonReferenceType();
-              // Get the location of the place we will insert.
-              SourceLocation Loc
-                = newBody[indexOfLastExpr]->getLocEnd().getLocWithOffset(1);
-              Expr* DRE = S->BuildDeclRefExpr(VD, VDTy,VK_LValue, Loc).get();
-              assert(DRE && "Cannot be null");
-              indexOfLastExpr++;
-              newBody.insert(newBody.begin() + indexOfLastExpr, DRE);
+  //             QualType VDTy = VD->getType().getNonReferenceType();
+  //             // Get the location of the place we will insert.
+  //             SourceLocation Loc
+  //               = newBody[indexOfLastExpr]->getLocEnd().getLocWithOffset(1);
+  //             Expr* DRE = S->BuildDeclRefExpr(VD, VDTy,VK_LValue, Loc).get();
+  //             assert(DRE && "Cannot be null");
+  //             indexOfLastExpr++;
+  //             newBody.insert(newBody.begin() + indexOfLastExpr, DRE);
 
-              // Attach the new body (note: it does dealloc/alloc of all nodes)
-              CS->setStmts(S->getASTContext(),
-                  CREATE_ARRAYREF(&newBody.front(), newBody.size()));
-              if (FoundAt)
-                *FoundAt = indexOfLastExpr;
-              return DRE;
-            }
-          }
-        }
+  //             // Attach the new body (note: it does dealloc/alloc of all nodes)
+  //             CS->setStmts(S->getASTContext(),
+  //                 CREATE_ARRAYREF(&newBody.front(), newBody.size()));
+  //             if (FoundAt)
+  //               *FoundAt = indexOfLastExpr;
+  //             return DRE;
+  //           }
+  //         }
+  //       }
 
-      return result;
-    }
+  //     return result;
+  //   }
 
-    return result;
-  }
+  //   return result;
+  // }
 
   const char* const Synthesize::UniquePrefix = "__cling_Un1Qu3";
 

--- a/external/cling/src/cling_utils_AST.cpp
+++ b/external/cling/src/cling_utils_AST.cpp
@@ -1411,48 +1411,48 @@ namespace utils {
     return dyn_cast<NamespaceDecl>(R.getFoundDecl());
   }
 
-  NamedDecl* Lookup::Named(Sema* S, llvm::StringRef Name,
-                           const DeclContext* Within) {
-    DeclarationName DName = &S->Context.Idents.get(Name);
-    return Lookup::Named(S, DName, Within);
-  }
+  // NamedDecl* Lookup::Named(Sema* S, llvm::StringRef Name,
+  //                          const DeclContext* Within) {
+  //   DeclarationName DName = &S->Context.Idents.get(Name);
+  //   return Lookup::Named(S, DName, Within);
+  // }
 
-  NamedDecl* Lookup::Named(Sema* S, const char* Name,
-                           const DeclContext* Within) {
-    DeclarationName DName = &S->Context.Idents.get(Name);
-    return Lookup::Named(S, DName, Within);
-  }
+  // NamedDecl* Lookup::Named(Sema* S, const char* Name,
+  //                          const DeclContext* Within) {
+  //   DeclarationName DName = &S->Context.Idents.get(Name);
+  //   return Lookup::Named(S, DName, Within);
+  // }
 
-  NamedDecl* Lookup::Named(Sema* S, const DeclarationName& Name,
-                           const DeclContext* Within) {
-    LookupResult R(*S, Name, SourceLocation(), Sema::LookupOrdinaryName,
-                   Sema::ForRedeclaration);
-    R.suppressDiagnostics();
-    if (!Within)
-      S->LookupName(R, S->TUScope);
-    else {
-      const DeclContext* primaryWithin = nullptr;
-      if (const clang::TagDecl *TD = dyn_cast<clang::TagDecl>(Within)) {
-        primaryWithin = dyn_cast_or_null<DeclContext>(TD->getDefinition());
-      } else {
-        primaryWithin = Within->getPrimaryContext();
-      }
-      if (!primaryWithin) {
-        // No definition, no lookup result.
-        return 0;
-      }
-      S->LookupQualifiedName(R, const_cast<DeclContext*>(primaryWithin));
-    }
+  // NamedDecl* Lookup::Named(Sema* S, const DeclarationName& Name,
+  //                          const DeclContext* Within) {
+  //   LookupResult R(*S, Name, SourceLocation(), Sema::LookupOrdinaryName,
+  //                  Sema::ForRedeclaration);
+  //   R.suppressDiagnostics();
+  //   if (!Within)
+  //     S->LookupName(R, S->TUScope);
+  //   else {
+  //     const DeclContext* primaryWithin = nullptr;
+  //     if (const clang::TagDecl *TD = dyn_cast<clang::TagDecl>(Within)) {
+  //       primaryWithin = dyn_cast_or_null<DeclContext>(TD->getDefinition());
+  //     } else {
+  //       primaryWithin = Within->getPrimaryContext();
+  //     }
+  //     if (!primaryWithin) {
+  //       // No definition, no lookup result.
+  //       return 0;
+  //     }
+  //     S->LookupQualifiedName(R, const_cast<DeclContext*>(primaryWithin));
+  //   }
 
-    if (R.empty())
-      return 0;
+  //   if (R.empty())
+  //     return 0;
 
-    R.resolveKind();
+  //   R.resolveKind();
 
-    if (R.isSingleResult())
-      return R.getFoundDecl();
-    return (clang::NamedDecl*)-1;
-  }
+  //   if (R.isSingleResult())
+  //     return R.getFoundDecl();
+  //   return (clang::NamedDecl*)-1;
+  // }
 
   static NestedNameSpecifier*
   CreateNestedNameSpecifierForScopeOf(const ASTContext& Ctx,


### PR DESCRIPTION
chimera cannot be built with LLVM 6 because the disabled functions use private members of LLVM 6 (they used to be public in older versions). It seems those functions are not used in chimera anyway.

Resolves #172 