### PR TITLE
Turn off DEBUG option for tests

### DIFF
--- a/test/01_function/CMakeLists.txt
+++ b/test/01_function/CMakeLists.txt
@@ -3,7 +3,6 @@ chimera_add_binding_tests(function
   EXTRA_SOURCES function.cpp
   NAMESPACES function
   CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/function.yaml
-  DEBUG
   COPY_MODULE
 )
 

--- a/test/02_class/CMakeLists.txt
+++ b/test/02_class/CMakeLists.txt
@@ -3,7 +3,6 @@ chimera_add_binding_tests(class
   EXTRA_SOURCES class.cpp
   NAMESPACES chimera_test
   CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/class.yaml
-  DEBUG
   COPY_MODULE
 )
 

--- a/test/03_smart_pointers/CMakeLists.txt
+++ b/test/03_smart_pointers/CMakeLists.txt
@@ -5,7 +5,6 @@ chimera_add_binding_test_pybind11(${test_name}_pybind11
   EXTRA_SOURCES ${test_name}.cpp
   NAMESPACES chimera_test
   CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}_pybind11.yaml
-  DEBUG
   COPY_MODULE
 )
 
@@ -15,7 +14,6 @@ chimera_add_binding_test_pybind11(${test_name}_pybind11
 #   EXTRA_SOURCES ${test_name}.cpp
 #   NAMESPACES chimera_test
 #   CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}_boost_python.yaml
-#   DEBUG
 #   COPY_MODULE
 # )
 

--- a/test/04_enumeration/CMakeLists.txt
+++ b/test/04_enumeration/CMakeLists.txt
@@ -5,7 +5,6 @@ chimera_add_binding_tests(${test_name}
   EXTRA_SOURCES ${test_name}.cpp
   NAMESPACES chimera_test
   CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.yaml
-  DEBUG
   COPY_MODULE
 )
 

--- a/test/05_variable/CMakeLists.txt
+++ b/test/05_variable/CMakeLists.txt
@@ -5,7 +5,6 @@ chimera_add_binding_tests(${test_name}
   EXTRA_SOURCES ${test_name}.cpp
   NAMESPACES chimera_test
   CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/${test_name}.yaml
-  DEBUG
   COPY_MODULE
 )
 

--- a/test/99_dart_example/CMakeLists.txt
+++ b/test/99_dart_example/CMakeLists.txt
@@ -2,7 +2,6 @@ chimera_add_binding_test_boost_python(dart_example_boost_python
   SOURCES dart_example.h
   NAMESPACES dart
   CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/dart_example.yaml
-  DEBUG
   COPY_MODULE
 )
 


### PR DESCRIPTION
As we're adding many tests, the prints are bloating too much (at least to me).