### PR TITLE
Make file and main optional in template configuration

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -78,6 +78,10 @@ chimera::util::extendWithYAMLNode(::mstch::map &map, const YAML::Node &node,
                                   bool overwrite,
                                   chimera::util::ScalarConversionFn fn)
 {
+    // Ignore invalid node.
+    if (!node)
+        return;
+
     // Ignore non-map types of YAML::Node.
     if (!node.IsMap())
         return;


### PR DESCRIPTION
Previously, `template` must contain both of `file` and `main` items. Otherwise, it causes a runtime error.

This PR relaxes the requirements so that we only overwrite what we want.

Alternatively, we could check the validity of the node before calling `extendWithYAMLNode()`, but I chose this way because it seems this function has another validity check (whether the node is a map) inside already.