### PR TITLE
Updating cling/Utils/AST.cpp to latest master

### DIFF
--- a/external/cling/include/cling_utils_AST.h
+++ b/external/cling/include/cling_utils_AST.h
@@ -76,6 +76,8 @@ namespace utils {
     ///                           synthesis of the DeclRefExpr.
     ///\returns 0 if the operation wasn't successful.
     ///
+    // DISABLED FOR CHIMERA:
+    // This function disabled because it's incompatible with LLVM (>=6)
     // clang::Expr* GetOrCreateLastExpr(clang::FunctionDecl* FD,
     //                                  int* FoundAt = 0,
     //                                  bool omitDeclStmts = true,
@@ -207,6 +209,8 @@ namespace utils {
     ///                    TranslationUnitDecl is used.
     ///\returns the found result if single, -1 if multiple or 0 if not found.
     ///
+    // DISABLED FOR CHIMERA:
+    // This function disabled because it's incompatible with LLVM (>=6)
     // clang::NamedDecl* Named(clang::Sema* S,
     //                         llvm::StringRef Name,
     //                         const clang::DeclContext* Within = 0);
@@ -220,6 +224,8 @@ namespace utils {
     ///                    TranslationUnitDecl is used.
     ///\returns the found result if single, -1 if multiple or 0 if not found.
     ///
+    // DISABLED FOR CHIMERA:
+    // This function disabled because it's incompatible with LLVM (>=6)
     // clang::NamedDecl* Named(clang::Sema* S,
     //                         const char* Name,
     //                         const clang::DeclContext* Within = 0);
@@ -234,6 +240,8 @@ namespace utils {
     ///                    TranslationUnitDecl is used.
     ///\returns the found result if single, -1 if multiple or 0 if not found.
     ///
+    // DISABLED FOR CHIMERA:
+    // This function disabled because it's incompatible with LLVM (>=6)
     // clang::NamedDecl* Named(clang::Sema* S,
     //                         const clang::DeclarationName& Name,
     //                         const clang::DeclContext* Within = 0);
@@ -247,6 +255,8 @@ namespace utils {
     ///                    TranslationUnitDecl is used.
     ///\returns the found result if single, -1 if multiple or 0 if not found.
     ///
+    // DISABLED FOR CHIMERA:
+    // This function disabled because it's incompatible with LLVM (>=6)
     // clang::TagDecl* Tag(clang::Sema* S,
     //                     llvm::StringRef Name,
     //                     const clang::DeclContext* Within = 0);
@@ -260,6 +270,8 @@ namespace utils {
     ///                    TranslationUnitDecl is used.
     ///\returns the found result if single, -1 if multiple or 0 if not found.
     ///
+    // DISABLED FOR CHIMERA:
+    // This function disabled because it's incompatible with LLVM (>=6)
     // clang::TagDecl* Tag(clang::Sema* S,
     //                     const char* Name,
     //                     const clang::DeclContext* Within = 0);
@@ -273,6 +285,8 @@ namespace utils {
     ///                    TranslationUnitDecl is used.
     ///\returns the found result if single, -1 if multiple or 0 if not found.
     ///
+    // DISABLED FOR CHIMERA:
+    // This function disabled because it's incompatible with LLVM (>=6)
     // clang::TagDecl* Tag(clang::Sema* S,
     //                     const clang::DeclarationName& Name,
     //                     const clang::DeclContext* Within = 0);

--- a/external/cling/src/cling_utils_AST.cpp
+++ b/external/cling/src/cling_utils_AST.cpp
@@ -129,6 +129,11 @@ namespace utils {
     RawStr.flush();
   }
 
+  ////////////////////////////
+  // DISABLED FOR CHIMERA:
+  // This function disabled because it's incompatible with LLVM (>=6)
+  ////////////////////////////
+  //
   // Expr* Analyze::GetOrCreateLastExpr(FunctionDecl* FD,
   //                                    int* FoundAt /*=0*/,
   //                                    bool omitDeclStmts /*=true*/,
@@ -1620,6 +1625,10 @@ namespace utils {
     // template parameter, this needs to be merged somehow with
     // GetPartialDesugaredType.
 
+    ////////////////////////////
+    // MODIFIED FOR CHIMERA
+    ////////////////////////////
+
     // Remove the part of the type related to the type being a template
     // parameter (we won't report it as part of the 'type name' and it is
     // actually make the code below to be more complex (to handle those)
@@ -1633,9 +1642,6 @@ namespace utils {
       QT = Ctx.getQualifiedType(QT, quals);
     }
 
-    ////////////////////////////
-    // ADDED FOR CHIMERA
-    ////////////////////////////
     if (llvm::isa<MemberPointerType>(QT.getTypePtr())) {
       Qualifiers quals = QT.getQualifiers();
 
@@ -1726,9 +1732,6 @@ namespace utils {
 
       return QT;
     }
-    ////////////////////////////
-    // END ADDED FOR CHIMERA
-    ////////////////////////////
 
     // In case of myType* we need to strip the pointer first, fully qualifiy
     // and attach the pointer once again.
@@ -1764,6 +1767,10 @@ namespace utils {
       if (!AutoTy->getDeducedType().isNull())
         return GetFullyQualifiedType(AutoTy->getDeducedType(), Ctx);
     }
+
+    ////////////////////////////
+    // END MODIFIED FOR CHIMERA
+    ////////////////////////////
 
     NestedNameSpecifier* prefix = 0;
     Qualifiers prefix_qualifiers;


### PR DESCRIPTION
## New Description
Originally, this PR was intended to test if #216 was solved by updating to the latest version of cling.  Our conclusion was that it is not.  As a result, this PR has roughly the same chimera-specific fixes in places as the prior version, but a more up-to-date cling source.

## Outdated Description
Based on the exploration in #220, it seems like we were able to localize the problem to a section of code in `cling/Utils/AST.cpp` that was incorrectly generating strings for template pointer type parameters.

From this, I went digging around the [cling codebase](https://github.com/root-project/cling/) and found that the section of code that @jslee02 had been permuting is actually slightly different in the latest `master`.

In this PR, I simply took the latest version of the `cling/Utils/AST.cpp` and inserted it over our version with minimal diff.  ~It seems to also pass the unit tests that @jslee02 had generated.~

As a side-effect, the helper functions that @jslee02 had previously removed due to references to clang internal members have been reintroduced, but these versions should be able to compile against clang >=3.8 without issue.  **We should carefully review the results of the automated unit tests across platforms before reintroducing these helper functions.**

----

*Update:*  After reintroducing all the necessary fixes from our fork of `AST.cpp`, this more or less looks the same as the existing fix in #220, except that it is rebased on the latest `AST.cpp` which has a few minor changes that improve compatibility with clang >= 3.8.

@jslee02 can you take a look and see if you think it's worth also putting in this rebase?  I think the success on unit tests is virtually identical.

https://github.com/personalrobotics/chimera/compare/template_pointer_type_v2...template_pointer_type_v3