### PR TITLE
Code formatting using ClangFormat 6.0

### DIFF
--- a/.ci/install_linux.sh
+++ b/.ci/install_linux.sh
@@ -30,6 +30,11 @@ $SUDO apt-get -y install lcov
 $SUDO apt-get -y install python-dev python3-dev
 $SUDO apt-get -y install libpython-dev libpython3-dev
 
+# Install ClangFormat 6
+if [ $(lsb_release -sc) = "bionic" ]; then
+  $SUDO apt-get -y install clang-format-6.0
+fi
+
 # Install pybind11 from source (we need pybind11 (>=2.2.0))
 git clone https://github.com/pybind/pybind11.git
 cd pybind11

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -14,7 +14,11 @@ else
   cmake "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" "-DLLVM_DIR=${LLVM_DIR}" "-DCODECOV=OFF" ..
 fi
 
-make
+make -j4
+
+if [ "$OS_NAME" = "linux" ] && [ $(lsb_release -sc) = "bionic" ]; then
+  make check-format
+fi
 
 if [ $BUILD_NAME = TRUSTY_GCC_DEBUG ]; then
   make chimera_coverage

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,89 @@
+---
+Language:        Cpp
+BasedOnStyle:   LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit:     80
+CommentPragmas:  ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+# Sort headers by main include file (implicit priority 0),
+# then project and private includes, then system headers
+IncludeCategories:
+  - Regex:     '^<([a-z|_]+)>'  # standard library headers
+    Priority:  1
+  - Regex:     '^(<[A-z]+)'     # dependency headers
+    Priority:  2
+  - Regex:     '^(<|")chimera/' # Chimera headers
+    Priority:  3
+  - Regex:     '^".*'           # headers relative to this project
+    Priority:  4
+IndentCaseLabels: true
+IndentFunctionDeclarationAfterType: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        4
+UseTab:          Never
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ set(SHARE_INSTALL_DIR "share/${PROJECT_NAME}")
 ## SETUP ##
 ###########
 
+# Preset for code formatting
+include(ClangFormat)
+clang_format_setup()
+
 ## Find necessary packages.
 find_package(LLVM REQUIRED CONFIG)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
@@ -124,6 +128,12 @@ target_link_libraries("${PROJECT_NAME}"
 add_subdirectory(bindings)
 target_link_libraries(chimera chimera_bindings)
 
+# Add main sources for code formatting
+clang_format_add_sources(
+  ${${PROJECT_NAME}_HEADERS}
+  ${${PROJECT_NAME}_SOURCES}
+)
+
 #############
 ## INSTALL ##
 #############
@@ -157,3 +167,10 @@ if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(test)
 endif()
+
+#####################
+## CODE FORMATTING ##
+#####################
+
+# Define 'format' target that runs ClangFormat
+clang_format_add_targets()

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,0 +1,60 @@
+function(clang_format_setup)
+  find_program(CLANG_FORMAT_EXECUTABLE NAMES clang-format-6.0)
+  if(NOT CLANG_FORMAT_EXECUTABLE)
+    message(STATUS "Looking for clang-format - NOT found, please install "
+      "clang-format to enable automatic code formatting."
+    )
+    return()
+  endif()
+
+  message(STATUS "Found clang-format.")
+endfunction()
+
+#===============================================================================
+function(_property_add property_name)
+  get_property(is_defined GLOBAL PROPERTY ${property_name} DEFINED)
+  if(NOT is_defined)
+    define_property(GLOBAL PROPERTY ${property_name}
+      BRIEF_DOCS "${property_name}"
+      FULL_DOCS "Global properties for ${property_name}"
+    )
+  endif()
+  foreach(item ${ARGN})
+    set_property(GLOBAL APPEND PROPERTY ${property_name} "${item}")
+  endforeach()
+endfunction()
+
+#===============================================================================
+function(clang_format_add_sources)
+  foreach(source ${ARGN})
+    if(IS_ABSOLUTE "${source}")
+      set(source_abs "${source}")
+    else()
+      get_filename_component(source_abs
+        "${CMAKE_CURRENT_LIST_DIR}/${source}" ABSOLUTE)
+    endif()
+    if(EXISTS "${source_abs}")
+      _property_add(CLANG_FORMAT_FORMAT_FILES "${source_abs}")
+    else()
+      message(FATAL_ERROR
+        "Source file '${source}' does not exist at absolute path"
+        " '${source_abs}'. This should never happen. Did you recently delete"
+        " this file or modify 'CMAKE_CURRENT_LIST_DIR'")
+    endif()
+  endforeach()
+endfunction()
+
+#===============================================================================
+function(clang_format_add_targets)
+  get_property(formatting_files GLOBAL PROPERTY CLANG_FORMAT_FORMAT_FILES)
+  list(LENGTH formatting_files formatting_files_length)
+  message(STATUS "Formatting on ${formatting_files_length} source files.")
+
+  add_custom_target(format
+    COMMAND ${CMAKE_COMMAND} -E echo "Formatting ${formatting_files_length} files..."
+    COMMAND ${CLANG_FORMAT_EXECUTABLE} -style=file -i ${formatting_files}
+    COMMAND ${CMAKE_COMMAND} -E echo "Done."
+    DEPENDS ${CLANG_FORMAT_EXECUTABLE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+endfunction()

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -57,4 +57,11 @@ function(clang_format_add_targets)
     DEPENDS ${CLANG_FORMAT_EXECUTABLE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
+  add_custom_target(check-format
+    COMMAND ${CMAKE_COMMAND} -E echo "Checking ${formatting_files_length} files..."
+    COMMAND ${CMAKE_SOURCE_DIR}/tools/check_format.sh ${CLANG_FORMAT_EXECUTABLE} ${formatting_files}
+    COMMAND ${CMAKE_COMMAND} -E echo "Done."
+    DEPENDS ${CLANG_FORMAT_EXECUTABLE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 endfunction()

--- a/include/chimera/binding.h
+++ b/include/chimera/binding.h
@@ -1,8 +1,8 @@
 #ifndef __CHIMERA_BINDING_H__
 #define __CHIMERA_BINDING_H__
 
-#include <string>
 #include <map>
+#include <string>
 
 namespace chimera
 {
@@ -12,7 +12,8 @@ namespace binding
 /**
  * Interface for defining a built-in language binding.
  */
-struct Definition {
+struct Definition
+{
     std::string class_cpp;
     std::string enum_cpp;
     std::string function_cpp;

--- a/include/chimera/configuration.h
+++ b/include/chimera/configuration.h
@@ -3,13 +3,13 @@
 
 #include "chimera/binding.h"
 
+#include <map>
+#include <memory>
+#include <set>
 #include <clang/AST/DeclBase.h>
 #include <clang/AST/Mangle.h>
 #include <clang/Frontend/CompilerInstance.h>
-#include <map>
-#include <memory>
 #include <mstch/mstch.hpp>
-#include <set>
 #include <yaml-cpp/yaml.h>
 
 namespace chimera
@@ -23,9 +23,8 @@ class Function;
 class Variable;
 class Namespace;
 
-} // mstch
-} // chimera
-
+} // namespace mstch
+} // namespace chimera
 
 namespace chimera
 {
@@ -35,13 +34,13 @@ class CompiledConfiguration;
 class Configuration
 {
 public:
-    Configuration(const Configuration&) = delete;
-    Configuration &operator=(const Configuration&) = delete;
+    Configuration(const Configuration &) = delete;
+    Configuration &operator=(const Configuration &) = delete;
 
     /**
      * Get the chimera configuration singleton for this process.
      */
-    static Configuration& GetInstance();
+    static Configuration &GetInstance();
 
     /**
      * Load the specified file to use as the YAML configuration.
@@ -81,28 +80,28 @@ public:
     /**
      * Process the configuration settings against the current AST.
      */
-    std::unique_ptr<CompiledConfiguration>
-    Process(clang::CompilerInstance *ci) const;
+    std::unique_ptr<CompiledConfiguration> Process(
+        clang::CompilerInstance *ci) const;
 
     /**
      * Get the root node of the YAML configuration structure.
      */
-    const YAML::Node& GetRoot() const;
+    const YAML::Node &GetRoot() const;
 
     /**
      * Get the filename of the loaded YAML configuration file, if it exists.
      */
-    const std::string& GetConfigFilename() const;
+    const std::string &GetConfigFilename() const;
 
     /**
      * Get the desired output path for bindings.
      */
-    const std::string& GetOutputPath() const;
+    const std::string &GetOutputPath() const;
 
     /**
      * Get the desired output python module name for top-level binding.
      */
-    const std::string& GetOutputModuleName() const;
+    const std::string &GetOutputModuleName() const;
 
 private:
     Configuration();
@@ -123,14 +122,14 @@ class CompiledConfiguration
 {
 public:
     virtual ~CompiledConfiguration();
-    CompiledConfiguration(const CompiledConfiguration&) = delete;
-    CompiledConfiguration &operator=(const CompiledConfiguration&) = delete;
+    CompiledConfiguration(const CompiledConfiguration &) = delete;
+    CompiledConfiguration &operator=(const CompiledConfiguration &) = delete;
 
     /**
      * Adds a namespace to an ordered set of traversed namespaces.
      * This set can later be rendered in a template.
      */
-    void AddTraversedNamespace(const clang::NamespaceDecl* decl);
+    void AddTraversedNamespace(const clang::NamespaceDecl *decl);
 
     /**
      * Return list of namespace declarations that should be included.
@@ -139,24 +138,25 @@ public:
      * is desirable since parent namespaces will naturally be lexically
      * ordered before their children.
      */
-    const std::set<const clang::NamespaceDecl*>& GetNamespacesIncluded() const;
+    const std::set<const clang::NamespaceDecl *> &GetNamespacesIncluded() const;
 
     /**
      * Returns list of namespace declarations that should be skipped.
      */
-    const std::set<const clang::NamespaceDecl*>& GetNamespacesSuppressed() const;
+    const std::set<const clang::NamespaceDecl *> &GetNamespacesSuppressed()
+        const;
 
     /**
      * Get the YAML configuration associated with a specific declaration,
      * or return an empty YAML node if no configuration was found.
      */
-    const YAML::Node& GetDeclaration(const clang::Decl *decl) const;
+    const YAML::Node &GetDeclaration(const clang::Decl *decl) const;
 
     /**
      * Get the YAML configuration associated with a specific qualified type,
      * or return an empty YAML node if no configuration was found.
      */
-    const YAML::Node& GetType(const clang::QualType type) const;
+    const YAML::Node &GetType(const clang::QualType type) const;
 
     /**
      * Gets the compiler instance used by this configuration.
@@ -198,7 +198,8 @@ public:
 
     /**
      * Render a particular mstch template based on some declaration.
-     * This context must contain a "mangled_name" from which to create the filename.
+     * This context must contain a "mangled_name" from which to create the
+     * filename.
      */
     bool Render(const std::shared_ptr<chimera::mstch::CXXRecord> context);
     bool Render(const std::shared_ptr<chimera::mstch::Enum> context);
@@ -220,13 +221,13 @@ protected:
     chimera::binding::Definition bindingDefinition_;
     clang::CompilerInstance *ci_;
     std::vector<std::pair<const clang::QualType, YAML::Node>> types_;
-    std::map<const clang::Decl*, YAML::Node> declarations_;
-    std::set<const clang::NamespaceDecl*> namespacesIncluded_;
-    std::set<const clang::NamespaceDecl*> namespacesSuppressed_;
+    std::map<const clang::Decl *, YAML::Node> declarations_;
+    std::set<const clang::NamespaceDecl *> namespacesIncluded_;
+    std::set<const clang::NamespaceDecl *> namespacesSuppressed_;
 
     std::vector<std::string> binding_names_;
     std::vector<std::shared_ptr<chimera::mstch::Namespace>> binding_namespaces_;
-    std::set<const clang::NamespaceDecl*> binding_namespace_decls_;
+    std::set<const clang::NamespaceDecl *> binding_namespace_decls_;
 
     friend class Configuration;
 };

--- a/include/chimera/frontend_action.h
+++ b/include/chimera/frontend_action.h
@@ -14,8 +14,8 @@ namespace chimera
 class FrontendAction : public clang::ASTFrontendAction
 {
 public:
-    virtual std::unique_ptr<clang::ASTConsumer>
-    CreateASTConsumer(clang::CompilerInstance &CI, clang::StringRef file);
+    virtual std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
+        clang::CompilerInstance &CI, clang::StringRef file);
 };
 
 } // namespace chimera

--- a/include/chimera/mstch.h
+++ b/include/chimera/mstch.h
@@ -12,10 +12,10 @@
 #include "chimera/configuration.h"
 #include "chimera/util.h"
 
+#include <sstream>
 #include <clang/AST/AST.h>
 #include <clang/AST/Comment.h>
 #include <mstch/mstch.hpp>
-#include <sstream>
 
 namespace chimera
 {
@@ -25,39 +25,47 @@ namespace mstch
 /**
  * Base mstch wrapper for Clang declarations.
  */
-template<typename T>
-class ClangWrapper: public ::mstch::object
+template <typename T>
+class ClangWrapper : public ::mstch::object
 {
-static_assert(std::is_base_of<clang::NamedDecl, T>::value,
-              "'T' must derive from clang::NamedDecl");
+    static_assert(std::is_base_of<clang::NamedDecl, T>::value,
+                  "'T' must derive from clang::NamedDecl");
+
 public:
-    ClangWrapper(const ::chimera::CompiledConfiguration &config,
-                 const T *decl, bool last=false)
-    : config_(config), decl_(decl)
-    , decl_config_(config_.GetDeclaration(decl_))
-    , last_(last)
+    ClangWrapper(const ::chimera::CompiledConfiguration &config, const T *decl,
+                 bool last = false)
+      : config_(config)
+      , decl_(decl)
+      , decl_config_(config_.GetDeclaration(decl_))
+      , last_(last)
     {
         // Add entries from the YAML configuration directly into the object.
         // This wraps each YAML node in a recursive conversion wrapper.
-        for(YAML::const_iterator it=decl_config_.begin(); it!=decl_config_.end(); ++it)
+        for (YAML::const_iterator it = decl_config_.begin();
+             it != decl_config_.end(); ++it)
         {
             const std::string name = it->first.as<std::string>();
             const YAML::Node &value = it->second;
-            register_lambda(name, [value]() { return chimera::util::wrapYAMLNode(value); });
+            register_lambda(
+                name, [value]() { return chimera::util::wrapYAMLNode(value); });
         }
 
         // Override certain entries with our clang-generated information.
-        register_methods(this, {
-            {"last", &ClangWrapper::last},
-            {"name", &ClangWrapper::name},
-            {"mangled_name", &ClangWrapper::mangledName},
-            {"qualified_name", &ClangWrapper::qualifiedName},
-            {"namespace_scope", &ClangWrapper::namespaceScope},
-            {"class_scope", &ClangWrapper::classScope},
-            {"scope", &ClangWrapper::scope},  // namespace_scope + class_scope
-            {"comment", &ClangWrapper::comment},
-            {"comment?", &ClangWrapper::isNonFalse<ClangWrapper, &ClangWrapper::comment>},
-        });
+        register_methods(
+            this,
+            {
+                {"last", &ClangWrapper::last},
+                {"name", &ClangWrapper::name},
+                {"mangled_name", &ClangWrapper::mangledName},
+                {"qualified_name", &ClangWrapper::qualifiedName},
+                {"namespace_scope", &ClangWrapper::namespaceScope},
+                {"class_scope", &ClangWrapper::classScope},
+                {"scope",
+                 &ClangWrapper::scope}, // namespace_scope + class_scope
+                {"comment", &ClangWrapper::comment},
+                {"comment?", &ClangWrapper::isNonFalse<ClangWrapper,
+                                                       &ClangWrapper::comment>},
+            });
     }
 
     ::mstch::node last()
@@ -123,30 +131,31 @@ public:
     virtual ::mstch::node comment()
     {
         ::mstch::array comment_lines;
-        const auto *comment =
-            config_.GetContext().getCommentForDecl(decl_->getCanonicalDecl(), nullptr);
+        const auto *comment = config_.GetContext().getCommentForDecl(
+            decl_->getCanonicalDecl(), nullptr);
 
         // Ignore empty/missing comments.
-        if(comment == nullptr)
+        if (comment == nullptr)
             return comment_lines;
 
         // Aggregate comment blocks into one large string.
-        for(auto comment_it = comment->child_begin();
-            comment_it != comment->child_end(); ++comment_it)
+        for (auto comment_it = comment->child_begin();
+             comment_it != comment->child_end(); ++comment_it)
         {
             // Look for block comment sections.
             const auto *commentSection = *comment_it;
-            if(commentSection->getCommentKind() !=
-                    clang::comments::BlockContentComment::ParagraphCommentKind)
+            if (commentSection->getCommentKind()
+                != clang::comments::BlockContentComment::ParagraphCommentKind)
                 continue;
 
             // Combine the inline text of these sections together.
-            for(auto text_it = commentSection->child_begin();
-                text_it != commentSection->child_end(); ++text_it)
+            for (auto text_it = commentSection->child_begin();
+                 text_it != commentSection->child_end(); ++text_it)
             {
-                if(clang::isa<clang::comments::TextComment>(*text_it))
+                if (clang::isa<clang::comments::TextComment>(*text_it))
                 {
-                    auto text = clang::cast<clang::comments::TextComment>(*text_it);
+                    auto text
+                        = clang::cast<clang::comments::TextComment>(*text_it);
                     comment_lines.push_back(text->getText().str());
                 }
             }
@@ -166,20 +175,21 @@ protected:
     const YAML::Node &decl_config_;
     bool last_;
 
-    template <typename Derived, ::mstch::node (Derived::*Func)() >
+    template <typename Derived, ::mstch::node (Derived::*Func)()>
     ::mstch::node isNonFalse()
     {
-        ::mstch::map context{{"data", (static_cast<Derived*>(this)->*Func)()}};
+        ::mstch::map context{{"data", (static_cast<Derived *>(this)->*Func)()}};
         return ::mstch::render("{{^data}}NONE{{/data}}", context).empty();
     }
 };
 
-class CXXRecord: public ClangWrapper<clang::CXXRecordDecl>
+class CXXRecord : public ClangWrapper<clang::CXXRecordDecl>
 {
 public:
     CXXRecord(const ::chimera::CompiledConfiguration &config,
               const clang::CXXRecordDecl *decl,
-              const std::set<const clang::CXXRecordDecl*> *available_decls = NULL);
+              const std::set<const clang::CXXRecordDecl *> *available_decls
+              = NULL);
 
     ::mstch::node bases();
     ::mstch::node type();
@@ -203,7 +213,7 @@ protected:
     const std::set<const clang::CXXRecordDecl *> *available_decls_;
 };
 
-class Enum: public ClangWrapper<clang::EnumDecl>
+class Enum : public ClangWrapper<clang::EnumDecl>
 {
 public:
     Enum(const ::chimera::CompiledConfiguration &config,
@@ -217,7 +227,7 @@ public:
     ::mstch::node values();
 };
 
-class EnumConstant: public ClangWrapper<clang::EnumConstantDecl>
+class EnumConstant : public ClangWrapper<clang::EnumConstantDecl>
 {
 public:
     EnumConstant(const ::chimera::CompiledConfiguration &config,
@@ -230,12 +240,11 @@ private:
     const clang::EnumDecl *enum_decl_;
 };
 
-class Field: public ClangWrapper<clang::FieldDecl>
+class Field : public ClangWrapper<clang::FieldDecl>
 {
 public:
     Field(const ::chimera::CompiledConfiguration &config,
-          const clang::FieldDecl *decl,
-          const clang::CXXRecordDecl *class_decl);
+          const clang::FieldDecl *decl, const clang::CXXRecordDecl *class_decl);
 
     ::mstch::node isAssignable();
     ::mstch::node isCopyable();
@@ -247,13 +256,13 @@ private:
 };
 
 // TODO: refactor Function to not need class_decl at all.
-class Function: public ClangWrapper<clang::FunctionDecl>,
-                public std::enable_shared_from_this<Function>
+class Function : public ClangWrapper<clang::FunctionDecl>,
+                 public std::enable_shared_from_this<Function>
 {
 public:
     Function(const ::chimera::CompiledConfiguration &config,
              const clang::FunctionDecl *decl,
-             const clang::CXXRecordDecl *class_decl=NULL,
+             const clang::CXXRecordDecl *class_decl = NULL,
              const int argument_limit = -1);
 
     ::mstch::node type();
@@ -276,12 +285,12 @@ private:
     const int argument_limit_;
 };
 
-class Method: public Function
+class Method : public Function
 {
 public:
     Method(const ::chimera::CompiledConfiguration &config,
            const clang::CXXMethodDecl *decl,
-           const clang::CXXRecordDecl *class_decl=NULL);
+           const clang::CXXRecordDecl *class_decl = NULL);
 
     ::mstch::node isConst();
     ::mstch::node isStatic();
@@ -290,7 +299,7 @@ private:
     const clang::CXXMethodDecl *method_decl_;
 };
 
-class Namespace: public ClangWrapper<clang::NamespaceDecl>
+class Namespace : public ClangWrapper<clang::NamespaceDecl>
 {
 public:
     Namespace(const ::chimera::CompiledConfiguration &config,
@@ -299,7 +308,7 @@ public:
     ::mstch::node scope();
 };
 
-class Parameter: public ClangWrapper<clang::ParmVarDecl>
+class Parameter : public ClangWrapper<clang::ParmVarDecl>
 {
 public:
     Parameter(const ::chimera::CompiledConfiguration &config,
@@ -317,12 +326,12 @@ private:
     const std::string default_name_;
 };
 
-class Variable: public ClangWrapper<clang::VarDecl>
+class Variable : public ClangWrapper<clang::VarDecl>
 {
 public:
     Variable(const ::chimera::CompiledConfiguration &config,
              const clang::VarDecl *decl,
-             const clang::CXXRecordDecl *class_decl=NULL);
+             const clang::CXXRecordDecl *class_decl = NULL);
 
     ::mstch::node isAssignable();
     ::mstch::node qualifiedName() override;
@@ -336,6 +345,5 @@ private:
 
 } // namespace mstch
 } // namespace chimera
-
 
 #endif // __CHIMERA_MSTCH_H__

--- a/include/chimera/util.h
+++ b/include/chimera/util.h
@@ -20,8 +20,9 @@ namespace util
  * to mstch context entries.  It optionally takes a scalar conversion function
  * which will be applied to scalars before they are re-wrapped by mstch.
  */
-using ScalarConversionFn = std::function<std::string(const YAML::Node&)>;
-::mstch::node wrapYAMLNode(const YAML::Node &node, ScalarConversionFn fn=nullptr);
+using ScalarConversionFn = std::function<std::string(const YAML::Node &)>;
+::mstch::node wrapYAMLNode(const YAML::Node &node,
+                           ScalarConversionFn fn = nullptr);
 
 /**
  * Adds entries from a YAML::Node to an existing mstch::map.
@@ -35,7 +36,8 @@ using ScalarConversionFn = std::function<std::string(const YAML::Node&)>;
  * false, existing properties will not be modified.
  */
 void extendWithYAMLNode(::mstch::map &map, const YAML::Node &node,
-                        bool overwrite=false, ScalarConversionFn fn=nullptr);
+                        bool overwrite = false,
+                        ScalarConversionFn fn = nullptr);
 
 /**
  * Resolve a declaration string within the scope of a compiler instance.
@@ -47,7 +49,7 @@ void extendWithYAMLNode(::mstch::map &map, const YAML::Node &node,
  * If it can be resolved to a named declaration, the canonical clang::Decl
  * pointer associated with the declaration will be returned, otherwise NULL.
  */
-const clang::NamedDecl* resolveDeclaration(clang::CompilerInstance *ci,
+const clang::NamedDecl *resolveDeclaration(clang::CompilerInstance *ci,
                                            const llvm::StringRef declStr);
 
 /**
@@ -60,7 +62,7 @@ const clang::NamedDecl* resolveDeclaration(clang::CompilerInstance *ci,
  * If it is resolved to a record declaration, the canonical clang::RecordDecl
  * pointer associated with the declaration will be returned, otherwise NULL.
  */
-const clang::RecordDecl* resolveRecord(clang::CompilerInstance *ci,
+const clang::RecordDecl *resolveRecord(clang::CompilerInstance *ci,
                                        const llvm::StringRef recordStr);
 
 /**
@@ -84,13 +86,12 @@ const clang::QualType resolveType(clang::CompilerInstance *ci,
  * form `namespace [nsStr] {};` within the AST that is currently loaded by the
  * provided compiler instance.
  *
- * If it is resolved to a namespace declaration, the canonical 
+ * If it is resolved to a namespace declaration, the canonical
  * clang::NamespaceDecl pointer associated with the namespace will be
  * returned, otherwise NULL.
  */
-const clang::NamespaceDecl* resolveNamespace(clang::CompilerInstance *ci,
+const clang::NamespaceDecl *resolveNamespace(clang::CompilerInstance *ci,
                                              const llvm::StringRef nsStr);
-
 
 /**
  * Convert the type into one with fully qualified template parameters.
@@ -234,7 +235,8 @@ bool needsReturnValuePolicy(const clang::NamedDecl *decl,
  *
  * This is possible when the function takes some number of default arguments.
  */
-std::pair<unsigned, unsigned> getFunctionArgumentRange(const clang::FunctionDecl *decl);
+std::pair<unsigned, unsigned> getFunctionArgumentRange(
+    const clang::FunctionDecl *decl);
 
 } // namespace util
 } // namespace chimera

--- a/include/chimera/visitor.h
+++ b/include/chimera/visitor.h
@@ -3,10 +3,10 @@
 
 #include "chimera/configuration.h"
 
+#include <set>
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/RecursiveASTVisitor.h>
 #include <clang/Frontend/CompilerInstance.h>
-#include <set>
 
 namespace chimera
 {

--- a/src/chimera.cpp
+++ b/src/chimera.cpp
@@ -4,12 +4,12 @@
 #include "chimera/configuration.h"
 #include "chimera/frontend_action.h"
 
-#include <clang/Tooling/CommonOptionsParser.h>
-#include <clang/Tooling/Tooling.h>
-#include <clang/Tooling/ArgumentsAdjusters.h>
-#include <llvm/Support/CommandLine.h>
 #include <memory>
 #include <string>
+#include <clang/Tooling/ArgumentsAdjusters.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <llvm/Support/CommandLine.h>
 
 #define STR_DETAIL(x) #x
 #define STR(x) STR_DETAIL(x)
@@ -24,15 +24,13 @@ static cl::OptionCategory ChimeraCategory("Chimera options");
 
 // Option for specifying binding type by name.
 static cl::opt<std::string> BindingName(
-    "b", cl::cat(ChimeraCategory),
-    cl::desc("Specify binding definition name"),
+    "b", cl::cat(ChimeraCategory), cl::desc("Specify binding definition name"),
     cl::value_desc("binding"));
 
 // Option for specifying output binding filename.
 static cl::opt<std::string> OutputPath(
     "o", cl::cat(ChimeraCategory),
-    cl::desc("Specify output bindings directory"),
-    cl::value_desc("directory"));
+    cl::desc("Specify output bindings directory"), cl::value_desc("directory"));
 
 // Option for specifying output binding filename.
 static cl::opt<std::string> OutputModuleName(
@@ -62,7 +60,8 @@ static cl::opt<bool> SuppressDocs(
     "no-docs", cl::cat(ChimeraCategory),
     cl::desc("Suppress the extraction of documentation from C++ comments"));
 
-// Option for preventing binding sources from being auto-forwarded in generated bindings.
+// Option for preventing binding sources from being auto-forwarded in generated
+// bindings.
 static cl::opt<bool> SuppressSources(
     "no-default-sources", cl::cat(ChimeraCategory),
     cl::desc("Suppress the forwarding of source file paths to binding"));
@@ -71,8 +70,7 @@ static cl::opt<bool> SuppressSources(
 static cl::extrahelp MoreHelp(
     "\n"
     "Chimera is a tool to convert C++ headers into Boost.Python bindings.\n"
-    "\n"
-);
+    "\n");
 
 int main(int argc, const char **argv)
 {
@@ -94,7 +92,8 @@ int main(int argc, const char **argv)
 
     // If a top-level binding file was specified, set configuration to use it.
     if (!OutputModuleName.empty())
-        chimera::Configuration::GetInstance().SetOutputModuleName(OutputModuleName);
+        chimera::Configuration::GetInstance().SetOutputModuleName(
+            OutputModuleName);
 
     // Add top-level namespaces to the configuration.
     if (NamespaceNames.size())
@@ -123,8 +122,9 @@ int main(int argc, const char **argv)
     // Add a workaround for the bug in clang shipped default with Ubuntu 14.04.
     // https://bugs.launchpad.net/ubuntu/+source/llvm-defaults/+bug/1242300
     Tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(
-        "-I/usr/lib/llvm-" STR(LLVM_VERSION_MAJOR) "." STR(LLVM_VERSION_MINOR)
-        "/lib/clang/" LLVM_VERSION_STRING "/include", ArgumentInsertPosition::END));
+        "-I/usr/lib/llvm-" STR(LLVM_VERSION_MAJOR) "." STR(
+            LLVM_VERSION_MINOR) "/lib/clang/" LLVM_VERSION_STRING "/include",
+        ArgumentInsertPosition::END));
 
     // Run the instantiated tool on the Chimera frontend.
     return Tool.run(newFrontendActionFactory<chimera::FrontendAction>().get());

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -5,8 +5,8 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <sstream>
 #include <map>
+#include <sstream>
 
 using namespace clang;
 
@@ -37,8 +37,8 @@ std::string sanitizePath(const std::string &path)
     // If the path length is long, compute a safe prefix and append an
     // incrementing counter variable to the end of the filename.
     size_t suffix_index = path.find_last_of(".");
-    const std::string path_suffix = (suffix_index == std::string::npos) ?
-                                    "" : path.substr(suffix_index);
+    const std::string path_suffix
+        = (suffix_index == std::string::npos) ? "" : path.substr(suffix_index);
     const int prefix_size = std::max(
         0, MAX_PATH_LENGTH - MAX_COUNTER_LENGTH - (int)path_suffix.size() - 2);
     const std::string path_prefix = path.substr(0, prefix_size);
@@ -55,18 +55,16 @@ std::string sanitizePath(const std::string &path)
 
 } // namespace
 
-
 const YAML::Node chimera::CompiledConfiguration::emptyNode_(
     YAML::NodeType::Undefined);
 
 chimera::Configuration::Configuration()
-: outputPath_(".")
-, outputModuleName_("chimera_binding")
+  : outputPath_("."), outputModuleName_("chimera_binding")
 {
     // Do nothing.
 }
 
-chimera::Configuration& chimera::Configuration::GetInstance()
+chimera::Configuration &chimera::Configuration::GetInstance()
 {
     static chimera::Configuration config;
     return config;
@@ -79,11 +77,12 @@ void chimera::Configuration::LoadFile(const std::string &filename)
         configNode_ = YAML::LoadFile(filename);
         configFilename_ = filename;
     }
-    catch(YAML::Exception& e)
+    catch (YAML::Exception &e)
     {
         // If unable to read the configuration YAML, terminate with an error.
         std::cerr << "Unable to read configuration '" << filename << "'."
-                  << std::endl << e.what() << std::endl;
+                  << std::endl
+                  << e.what() << std::endl;
         exit(-1);
     }
 }
@@ -127,7 +126,8 @@ void chimera::Configuration::SetOutputModuleName(const std::string &moduleName)
     outputModuleName_ = moduleName;
 }
 
-void chimera::Configuration::AddInputNamespaceName(const std::string &namespaceName)
+void chimera::Configuration::AddInputNamespaceName(
+    const std::string &namespaceName)
 {
     inputNamespaceNames_.push_back(namespaceName);
 }
@@ -137,14 +137,14 @@ void chimera::Configuration::AddSourcePath(const std::string &sourcePath)
     inputSourcePaths_.push_back(sourcePath);
 }
 
-std::unique_ptr<chimera::CompiledConfiguration>
-chimera::Configuration::Process(CompilerInstance *ci) const
+std::unique_ptr<chimera::CompiledConfiguration> chimera::Configuration::Process(
+    CompilerInstance *ci) const
 {
     return std::unique_ptr<chimera::CompiledConfiguration>(
         new CompiledConfiguration(*this, ci));
 }
 
-const YAML::Node& chimera::Configuration::GetRoot() const
+const YAML::Node &chimera::Configuration::GetRoot() const
 {
     return configNode_;
 }
@@ -166,10 +166,10 @@ const std::string &chimera::Configuration::GetOutputModuleName() const
 
 chimera::CompiledConfiguration::CompiledConfiguration(
     const chimera::Configuration &parent, CompilerInstance *ci)
-: parent_(parent)
-, configNode_(parent.GetRoot()) // TODO: do we need this reference?
-, bindingNode_(configNode_["template"]) // TODO: is this always ok?
-, ci_(ci)
+  : parent_(parent)
+  , configNode_(parent.GetRoot())         // TODO: do we need this reference?
+  , bindingNode_(configNode_["template"]) // TODO: is this always ok?
+  , ci_(ci)
 {
     // This placeholder will be filled in by the binding name specified
     // in the configuration YAML if it exists, or remain empty otherwise.
@@ -244,7 +244,7 @@ chimera::CompiledConfiguration::CompiledConfiguration(
             }
 
             // Resolve class/struct configuration entries within provided AST.
-            for(const auto &it : configNode_["classes"])
+            for (const auto &it : configNode_["classes"])
             {
                 std::string decl_str = it.first.as<std::string>();
                 auto decl = chimera::util::resolveRecord(ci, decl_str);
@@ -274,7 +274,7 @@ chimera::CompiledConfiguration::CompiledConfiguration(
             }
 
             // Resolve function configuration entries within provided AST.
-            for(const auto &it : functionsNode)
+            for (const auto &it : functionsNode)
             {
                 std::string decl_str = it.first.as<std::string>();
                 auto decl = chimera::util::resolveDeclaration(ci, decl_str);
@@ -304,7 +304,7 @@ chimera::CompiledConfiguration::CompiledConfiguration(
             }
 
             // Resolve type configuration entries within provided AST.
-            for(const auto &it : typesNode)
+            for (const auto &it : typesNode)
             {
                 std::string type_str = it.first.as<std::string>();
                 auto type = chimera::util::resolveType(ci, type_str);
@@ -336,10 +336,9 @@ chimera::CompiledConfiguration::CompiledConfiguration(
         }
     }
 
-    // Set the binding name from one of the following sources in order of priority:
-    // 1) CLI '--binding' setting
-    // 2) YAML configuration setting
-    // 3) chimera::binding::DEFAULT_NAME
+    // Set the binding name from one of the following sources in order of
+    // priority: 1) CLI '--binding' setting 2) YAML configuration setting 3)
+    // chimera::binding::DEFAULT_NAME
     std::string binding_name;
     if (!parent_.bindingName_.empty())
     {
@@ -385,14 +384,13 @@ chimera::CompiledConfiguration::CompiledConfiguration(
 
     // Set custom escape function that disables HTML escaping on mstch output.
     //
-    // This is not desirable in chimera because many C++ types include characters
-    // that can be accidentally escaped, such as `<>` and `&`.
+    // This is not desirable in chimera because many C++ types include
+    // characters that can be accidentally escaped, such as `<>` and `&`.
     //
     // See: https://github.com/no1msd/mstch#custom-escape-function
     //
-    ::mstch::config::escape = [](const std::string& str) -> std::string {
-        return str;
-    };
+    ::mstch::config::escape
+        = [](const std::string &str) -> std::string { return str; };
 }
 
 chimera::CompiledConfiguration::~CompiledConfiguration()
@@ -400,38 +398,36 @@ chimera::CompiledConfiguration::~CompiledConfiguration()
     // Create and sanitize path and filename of top-level source file.
     // Because we may compress the filename to fit OS character limits,
     // we generate the full path, then split the filename from it.
-    const std::string binding_path =
-        sanitizePath(parent_.GetOutputPath() + "/" +
-                     parent_.GetOutputModuleName() + ".cpp");
+    const std::string binding_path = sanitizePath(
+        parent_.GetOutputPath() + "/" + parent_.GetOutputModuleName() + ".cpp");
     size_t path_index = binding_path.find_last_of("/");
-    const std::string binding_filename =
-        (path_index == std::string::npos) ?
-            "" : binding_path.substr(path_index + 1);
+    const std::string binding_filename
+        = (path_index == std::string::npos)
+              ? ""
+              : binding_path.substr(path_index + 1);
 
     // Create an output file depending on the provided parameters.
     auto stream = ci_->createOutputFile(
         binding_path,
         false, // Open the file in binary mode
         false, // Register with llvm::sys::RemoveFileOnSignal
-        "", // The derived basename (shouldn't be used)
-        "", // The extension to use for derived name (shouldn't be used)
+        "",    // The derived basename (shouldn't be used)
+        "",    // The extension to use for derived name (shouldn't be used)
         false, // Use a temporary file that should be renamed
-        false // Create missing directories in the output path
+        false  // Create missing directories in the output path
     );
 
     // If file creation failed, report the error and fail immediately.
     if (!stream)
     {
         std::cerr << "Failed to create top-level output file "
-                  << "'" << binding_path << "'."
-                  << std::endl;
+                  << "'" << binding_path << "'." << std::endl;
         exit(-4);
     }
 
     // Create collections for the ordered sets of bindings, sources,
     // and namespaces.
-    ::mstch::array binding_names(binding_names_.begin(),
-                                 binding_names_.end());
+    ::mstch::array binding_names(binding_names_.begin(), binding_names_.end());
     ::mstch::array binding_namespaces(binding_namespaces_.begin(),
                                       binding_namespaces_.end());
     ::mstch::array binding_sources(parent_.inputSourcePaths_.begin(),
@@ -439,15 +435,13 @@ chimera::CompiledConfiguration::~CompiledConfiguration()
 
     // Create a top-level context that contains the extracted information
     // about the module.
-    ::mstch::map full_context {
-        {"module", ::mstch::map {
-            {"name", parent_.GetOutputModuleName()},
-            {"bindings", binding_names},
-            {"sources", binding_sources},
-            // Note: binding namespaces will be lexically ordered.
-            {"namespaces", binding_namespaces}
-        }}
-    };
+    ::mstch::map full_context{
+        {"module",
+         ::mstch::map{{"name", parent_.GetOutputModuleName()},
+                      {"bindings", binding_names},
+                      {"sources", binding_sources},
+                      // Note: binding namespaces will be lexically ordered.
+                      {"namespaces", binding_namespaces}}}};
 
     // Resolve customizable snippets that will be inserted into the file
     // from the configuration file's "template::main" entry.
@@ -455,9 +449,8 @@ chimera::CompiledConfiguration::~CompiledConfiguration()
     {
         chimera::util::extendWithYAMLNode(
             full_context, bindingNode_["main"], false,
-            std::bind(&chimera::CompiledConfiguration::Lookup,
-                      this, std::placeholders::_1)
-        );
+            std::bind(&chimera::CompiledConfiguration::Lookup, this,
+                      std::placeholders::_1));
     }
 
     // Render the mstch template to the given output file.
@@ -465,8 +458,8 @@ chimera::CompiledConfiguration::~CompiledConfiguration()
     std::cout << binding_filename << std::endl;
 }
 
-void
-chimera::CompiledConfiguration::AddTraversedNamespace(const clang::NamespaceDecl* decl)
+void chimera::CompiledConfiguration::AddTraversedNamespace(
+    const clang::NamespaceDecl *decl)
 {
     // Skip namespaces that are defined as null in the configuration.
     for (const auto &it : GetNamespacesSuppressed())
@@ -481,7 +474,8 @@ chimera::CompiledConfiguration::AddTraversedNamespace(const clang::NamespaceDecl
     // We first use a set to de-duplicate the namespaces using their canonical
     // decl pointers, then insert the renderable proxy of new namespaces into
     // a vector which will preserve their order during Render().
-    const auto result = binding_namespace_decls_.insert(decl->getCanonicalDecl());
+    const auto result
+        = binding_namespace_decls_.insert(decl->getCanonicalDecl());
     if (result.second)
     {
         binding_namespaces_.push_back(
@@ -489,27 +483,27 @@ chimera::CompiledConfiguration::AddTraversedNamespace(const clang::NamespaceDecl
     }
 }
 
-const std::set<const clang::NamespaceDecl*>&
-chimera::CompiledConfiguration::GetNamespacesIncluded() const
+const std::set<const clang::NamespaceDecl *>
+    &chimera::CompiledConfiguration::GetNamespacesIncluded() const
 {
     return namespacesIncluded_;
 }
 
-const std::set<const clang::NamespaceDecl*>&
-chimera::CompiledConfiguration::GetNamespacesSuppressed() const
+const std::set<const clang::NamespaceDecl *>
+    &chimera::CompiledConfiguration::GetNamespacesSuppressed() const
 {
     return namespacesSuppressed_;
 }
 
-const YAML::Node&
-chimera::CompiledConfiguration::GetDeclaration(const clang::Decl *decl) const
+const YAML::Node &chimera::CompiledConfiguration::GetDeclaration(
+    const clang::Decl *decl) const
 {
     const auto d = declarations_.find(decl->getCanonicalDecl());
     return d != declarations_.end() ? d->second : emptyNode_;
 }
 
-const YAML::Node&
-chimera::CompiledConfiguration::GetType(const clang::QualType type) const
+const YAML::Node &chimera::CompiledConfiguration::GetType(
+    const clang::QualType type) const
 {
     const auto canonical_type = type.getCanonicalType();
     for (const auto &entry : types_)
@@ -520,7 +514,8 @@ chimera::CompiledConfiguration::GetType(const clang::QualType type) const
     return emptyNode_;
 }
 
-clang::CompilerInstance *chimera::CompiledConfiguration::GetCompilerInstance() const
+clang::CompilerInstance *chimera::CompiledConfiguration::GetCompilerInstance()
+    const
 {
     return ci_;
 }
@@ -571,18 +566,16 @@ bool chimera::CompiledConfiguration::IsSuppressed(const clang::Decl *decl) const
     if (isa<FunctionDecl>(decl) && !config["return_value_policy"])
     {
         const FunctionDecl *function_decl = cast<FunctionDecl>(decl);
-        const QualType return_qual_type =
-            chimera::util::getFullyQualifiedType(
-                GetContext(), function_decl->getReturnType());
+        const QualType return_qual_type = chimera::util::getFullyQualifiedType(
+            GetContext(), function_decl->getReturnType());
         return IsSuppressed(return_qual_type);
     }
     // Fields can be suppressed if they represent a suppressed type.
     else if (isa<FieldDecl>(decl) && !config["return_value_policy"])
     {
         const FieldDecl *field_decl = cast<FieldDecl>(decl);
-        const QualType value_qual_type =
-            chimera::util::getFullyQualifiedType(
-                GetContext(), field_decl->getType());
+        const QualType value_qual_type = chimera::util::getFullyQualifiedType(
+            GetContext(), field_decl->getType());
         return IsSuppressed(value_qual_type);
     }
 
@@ -627,8 +620,8 @@ std::string chimera::CompiledConfiguration::Lookup(const YAML::Node &node) const
         std::ifstream source(source_path);
         if (source.fail())
         {
-            std::cerr << "Failed to open source '"
-                      << source_path << "': " << strerror(errno) << std::endl;
+            std::cerr << "Failed to open source '" << source_path
+                      << "': " << strerror(errno) << std::endl;
             exit(-5);
         }
 
@@ -643,14 +636,15 @@ std::string chimera::CompiledConfiguration::Lookup(const YAML::Node &node) const
     return node.as<std::string>();
 }
 
-bool
-chimera::CompiledConfiguration::Render(std::string view, std::string key,
-                                       const std::shared_ptr<::mstch::object> &context)
+bool chimera::CompiledConfiguration::Render(
+    std::string view, std::string key,
+    const std::shared_ptr<::mstch::object> &context)
 {
     // Get the mangled name property if it exists.
     if (!context->has("mangled_name"))
     {
-        std::cerr << "Cannot serialize template with no mangled name." << std::endl;
+        std::cerr << "Cannot serialize template with no mangled name."
+                  << std::endl;
         return false;
     }
     std::string mangled_name = ::mstch::render("{{mangled_name}}", context);
@@ -658,22 +652,23 @@ chimera::CompiledConfiguration::Render(std::string view, std::string key,
     // Create and sanitize path and filename of top-level source file.
     // Because we may compress the filename to fit OS character limits,
     // we generate the full path, then split the filename from it.
-    const std::string binding_path =
-        sanitizePath(parent_.GetOutputPath() + "/" + mangled_name + ".cpp");
+    const std::string binding_path
+        = sanitizePath(parent_.GetOutputPath() + "/" + mangled_name + ".cpp");
     size_t path_index = binding_path.find_last_of("/");
-    const std::string binding_filename =
-        (path_index == std::string::npos) ?
-            "" : binding_path.substr(path_index + 1);
+    const std::string binding_filename
+        = (path_index == std::string::npos)
+              ? ""
+              : binding_path.substr(path_index + 1);
 
     // Create an output file depending on the provided parameters.
     auto stream = ci_->createOutputFile(
         binding_path,
         false, // Open the file in binary mode
         false, // Register with llvm::sys::RemoveFileOnSignal
-        "", // The derived basename (shouldn't be used)
-        "", // The extension to use for derived name (shouldn't be used)
+        "",    // The derived basename (shouldn't be used)
+        "",    // The extension to use for derived name (shouldn't be used)
         false, // Use a temporary file that should be renamed
-        false // Create missing directories in the output path
+        false  // Create missing directories in the output path
     );
 
     // If file creation failed, report the error and fail immediately.
@@ -693,10 +688,7 @@ chimera::CompiledConfiguration::Render(std::string view, std::string key,
 
     // Create a top-level context that contains the extracted information
     // about this particular binding component.
-    ::mstch::map full_context {
-        {key, context},
-        {"sources", binding_sources}
-    };
+    ::mstch::map full_context{{key, context}, {"sources", binding_sources}};
 
     // Resolve customizable snippets that will be inserted into the file
     // from the configuration file's "template::file" entry.
@@ -704,9 +696,8 @@ chimera::CompiledConfiguration::Render(std::string view, std::string key,
     {
         chimera::util::extendWithYAMLNode(
             full_context, bindingNode_["file"], false,
-            std::bind(&chimera::CompiledConfiguration::Lookup,
-                      this, std::placeholders::_1)
-        );
+            std::bind(&chimera::CompiledConfiguration::Lookup, this,
+                      std::placeholders::_1));
     }
 
     // Render the mstch template to the given output file.
@@ -718,22 +709,26 @@ chimera::CompiledConfiguration::Render(std::string view, std::string key,
     return true;
 }
 
-bool chimera::CompiledConfiguration::Render(const std::shared_ptr<chimera::mstch::CXXRecord> context)
+bool chimera::CompiledConfiguration::Render(
+    const std::shared_ptr<chimera::mstch::CXXRecord> context)
 {
     return Render(bindingDefinition_.class_cpp, "class", context);
 }
 
-bool chimera::CompiledConfiguration::Render(const std::shared_ptr<chimera::mstch::Enum> context)
+bool chimera::CompiledConfiguration::Render(
+    const std::shared_ptr<chimera::mstch::Enum> context)
 {
     return Render(bindingDefinition_.enum_cpp, "enum", context);
 }
 
-bool chimera::CompiledConfiguration::Render(const std::shared_ptr<chimera::mstch::Function> context)
+bool chimera::CompiledConfiguration::Render(
+    const std::shared_ptr<chimera::mstch::Function> context)
 {
     return Render(bindingDefinition_.function_cpp, "function", context);
 }
 
-bool chimera::CompiledConfiguration::Render(const std::shared_ptr<chimera::mstch::Variable> context)
+bool chimera::CompiledConfiguration::Render(
+    const std::shared_ptr<chimera::mstch::Variable> context)
 {
     return Render(bindingDefinition_.variable_cpp, "variable", context);
 }

--- a/src/consumer.cpp
+++ b/src/consumer.cpp
@@ -6,9 +6,8 @@
 
 using namespace clang;
 
-chimera::Consumer::Consumer(CompilerInstance *ci)
-: ci_(ci)
-{ 
+chimera::Consumer::Consumer(CompilerInstance *ci) : ci_(ci)
+{
     // Do nothing.
 }
 

--- a/src/frontend_action.cpp
+++ b/src/frontend_action.cpp
@@ -5,8 +5,8 @@
 
 using namespace clang;
 
-std::unique_ptr<clang::ASTConsumer> 
-chimera::FrontendAction::CreateASTConsumer(CompilerInstance &CI, StringRef file) 
+std::unique_ptr<clang::ASTConsumer> chimera::FrontendAction::CreateASTConsumer(
+    CompilerInstance &CI, StringRef file)
 {
     CI.getPreprocessor().getDiagnostics().setIgnoreAllWarnings(true);
     return std::unique_ptr<chimera::Consumer>(new chimera::Consumer(&CI));

--- a/src/mstch.cpp
+++ b/src/mstch.cpp
@@ -1,12 +1,12 @@
-#include "chimera/configuration.h"
 #include "chimera/mstch.h"
+#include "chimera/configuration.h"
 #include "chimera/util.h"
 #include "cling_utils_AST.h"
 
-#include <boost/variant/get.hpp>
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <boost/variant/get.hpp>
 
 using namespace clang;
 
@@ -23,26 +23,26 @@ namespace mstch
     {
         switch (nns->getKind())
         {
-        case NestedNameSpecifier::Namespace:
-        {
-            NamespaceDecl *parent_decl =
-                nns->getAsNamespace()->getCanonicalDecl();
-            scope_templates.push_back(
-                std::make_shared<Namespace>(config, parent_decl));
-            break;
-        }
-        case NestedNameSpecifier::TypeSpec:
-            break;
-        case NestedNameSpecifier::Global:
-        case NestedNameSpecifier::Identifier:
-        case NestedNameSpecifier::NamespaceAlias:
-        case NestedNameSpecifier::Super:
-        case NestedNameSpecifier::TypeSpecWithTemplate:
-            throw std::runtime_error(
-                "Unsupported type of NestedNameSpecifier.");
-        default:
-            throw std::runtime_error(
-                "Unknown type of NestedNameSpecifier.");
+            case NestedNameSpecifier::Namespace:
+            {
+                NamespaceDecl *parent_decl
+                    = nns->getAsNamespace()->getCanonicalDecl();
+                scope_templates.push_back(
+                    std::make_shared<Namespace>(config, parent_decl));
+                break;
+            }
+            case NestedNameSpecifier::TypeSpec:
+                break;
+            case NestedNameSpecifier::Global:
+            case NestedNameSpecifier::Identifier:
+            case NestedNameSpecifier::NamespaceAlias:
+            case NestedNameSpecifier::Super:
+            case NestedNameSpecifier::TypeSpecWithTemplate:
+                throw std::runtime_error(
+                    "Unsupported type of NestedNameSpecifier.");
+            default:
+                throw std::runtime_error(
+                    "Unknown type of NestedNameSpecifier.");
         }
 
         nns = nns->getPrefix();
@@ -52,9 +52,8 @@ namespace mstch
     return scope_templates;
 }
 
-::mstch::node generateNamespace(
-    const ::chimera::CompiledConfiguration &config,
-    const clang::DeclContext *decl_context)
+::mstch::node generateNamespace(const ::chimera::CompiledConfiguration &config,
+                                const clang::DeclContext *decl_context)
 {
     if (!decl_context)
         throw std::runtime_error("Decl was not enclosed by a context.");
@@ -68,8 +67,8 @@ namespace mstch
         throw std::runtime_error(ss.str());
     }
 
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config.GetContext(), namespace_decl->getCanonicalDecl());
 
     return generateNamespace(config, nns);
@@ -84,29 +83,29 @@ namespace mstch
     {
         switch (nns->getKind())
         {
-        case NestedNameSpecifier::TypeSpec:
-        {
-            CXXRecordDecl *parent_decl =
-                nns->getAsType()->getAsCXXRecordDecl();
-            if (!parent_decl)
+            case NestedNameSpecifier::TypeSpec:
+            {
+                CXXRecordDecl *parent_decl
+                    = nns->getAsType()->getAsCXXRecordDecl();
+                if (!parent_decl)
+                    throw std::runtime_error(
+                        "TypeSpec was not a CXXRecordDecl.");
+                scope_templates.push_back(
+                    std::make_shared<CXXRecord>(config, parent_decl));
+                break;
+            }
+            case NestedNameSpecifier::Namespace:
+                break;
+            case NestedNameSpecifier::Global:
+            case NestedNameSpecifier::Identifier:
+            case NestedNameSpecifier::NamespaceAlias:
+            case NestedNameSpecifier::Super:
+            case NestedNameSpecifier::TypeSpecWithTemplate:
                 throw std::runtime_error(
-                    "TypeSpec was not a CXXRecordDecl.");
-            scope_templates.push_back(
-                std::make_shared<CXXRecord>(config, parent_decl));
-            break;
-        }
-        case NestedNameSpecifier::Namespace:
-            break;
-        case NestedNameSpecifier::Global:
-        case NestedNameSpecifier::Identifier:
-        case NestedNameSpecifier::NamespaceAlias:
-        case NestedNameSpecifier::Super:
-        case NestedNameSpecifier::TypeSpecWithTemplate:
-            throw std::runtime_error(
-                "Unsupported type of NestedNameSpecifier.");
-        default:
-            throw std::runtime_error(
-                "Unknown type of NestedNameSpecifier.");
+                    "Unsupported type of NestedNameSpecifier.");
+            default:
+                throw std::runtime_error(
+                    "Unknown type of NestedNameSpecifier.");
         }
 
         nns = nns->getPrefix();
@@ -132,8 +131,8 @@ namespace mstch
         throw std::runtime_error(ss.str());
     }
 
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config.GetContext(), namespace_decl->getCanonicalDecl());
 
     return generateScopeWithoutNamespace(config, nns);
@@ -147,35 +146,35 @@ namespace mstch
     {
         switch (nns->getKind())
         {
-        case NestedNameSpecifier::Namespace:
-        {
-            NamespaceDecl *parent_decl =
-                nns->getAsNamespace()->getCanonicalDecl();
-            scope_templates.push_back(
-                std::make_shared<Namespace>(config, parent_decl));
-            break;
-        }
-        case NestedNameSpecifier::TypeSpec:
-        {
-            CXXRecordDecl *parent_decl =
-                nns->getAsType()->getAsCXXRecordDecl();
-            if (!parent_decl)
+            case NestedNameSpecifier::Namespace:
+            {
+                NamespaceDecl *parent_decl
+                    = nns->getAsNamespace()->getCanonicalDecl();
+                scope_templates.push_back(
+                    std::make_shared<Namespace>(config, parent_decl));
+                break;
+            }
+            case NestedNameSpecifier::TypeSpec:
+            {
+                CXXRecordDecl *parent_decl
+                    = nns->getAsType()->getAsCXXRecordDecl();
+                if (!parent_decl)
+                    throw std::runtime_error(
+                        "TypeSpec was not a CXXRecordDecl.");
+                scope_templates.push_back(
+                    std::make_shared<CXXRecord>(config, parent_decl));
+                break;
+            }
+            case NestedNameSpecifier::Global:
+            case NestedNameSpecifier::Identifier:
+            case NestedNameSpecifier::NamespaceAlias:
+            case NestedNameSpecifier::Super:
+            case NestedNameSpecifier::TypeSpecWithTemplate:
                 throw std::runtime_error(
-                    "TypeSpec was not a CXXRecordDecl.");
-            scope_templates.push_back(
-                std::make_shared<CXXRecord>(config, parent_decl));
-            break;
-        }
-        case NestedNameSpecifier::Global:
-        case NestedNameSpecifier::Identifier:
-        case NestedNameSpecifier::NamespaceAlias:
-        case NestedNameSpecifier::Super:
-        case NestedNameSpecifier::TypeSpecWithTemplate:
-            throw std::runtime_error(
-                "Unsupported type of NestedNameSpecifier.");
-        default:
-            throw std::runtime_error(
-                "Unknown type of NestedNameSpecifier.");
+                    "Unsupported type of NestedNameSpecifier.");
+            default:
+                throw std::runtime_error(
+                    "Unknown type of NestedNameSpecifier.");
         }
 
         nns = nns->getPrefix();
@@ -200,36 +199,40 @@ namespace mstch
         throw std::runtime_error(ss.str());
     }
 
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config.GetContext(), namespace_decl->getCanonicalDecl());
 
     return generateScope(config, nns);
 }
 
-CXXRecord::CXXRecord(
-    const ::chimera::CompiledConfiguration &config,
-    const CXXRecordDecl *decl,
-    const std::set<const CXXRecordDecl*> *available_decls)
-: ClangWrapper(config, decl)
-, available_decls_(available_decls)
+CXXRecord::CXXRecord(const ::chimera::CompiledConfiguration &config,
+                     const CXXRecordDecl *decl,
+                     const std::set<const CXXRecordDecl *> *available_decls)
+  : ClangWrapper(config, decl), available_decls_(available_decls)
 {
-    register_methods(this, {
-        {"bases", &CXXRecord::bases},
-        {"bases?", &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::bases>},
-        {"type", &CXXRecord::type},
-        {"is_copyable", &CXXRecord::isCopyable},
-        {"constructors", &CXXRecord::constructors},
-        {"constructors?", &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::constructors>},
-        {"methods", &CXXRecord::methods},
-        {"methods?", &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::methods>},
-        {"fields", &CXXRecord::fields},
-        {"fields?", &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::fields>},
-        {"static_fields", &CXXRecord::staticFields},
-        {"static_fields?", &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::staticFields>},
-        {"static_methods", &CXXRecord::staticMethods},
-        {"static_methods?", &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::methods>},
-    });
+    register_methods(
+        this,
+        {
+            {"bases", &CXXRecord::bases},
+            {"bases?", &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::bases>},
+            {"type", &CXXRecord::type},
+            {"is_copyable", &CXXRecord::isCopyable},
+            {"constructors", &CXXRecord::constructors},
+            {"constructors?",
+             &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::constructors>},
+            {"methods", &CXXRecord::methods},
+            {"methods?",
+             &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::methods>},
+            {"fields", &CXXRecord::fields},
+            {"fields?", &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::fields>},
+            {"static_fields", &CXXRecord::staticFields},
+            {"static_fields?",
+             &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::staticFields>},
+            {"static_methods", &CXXRecord::staticMethods},
+            {"static_methods?",
+             &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::methods>},
+        });
 }
 
 ::mstch::node CXXRecord::bases()
@@ -238,33 +241,30 @@ CXXRecord::CXXRecord(
         return chimera::util::wrapYAMLNode(node);
 
     // Get all bases of this class.
-    std::set<const CXXRecordDecl *> base_decls =
-        chimera::util::getBaseClassDecls(decl_);
+    std::set<const CXXRecordDecl *> base_decls
+        = chimera::util::getBaseClassDecls(decl_);
 
-    // If a list of available decls is provided, only use available base classes.
+    // If a list of available decls is provided, only use available base
+    // classes.
     if (available_decls_)
     {
         std::set<const CXXRecordDecl *> available_base_decls;
         std::copy_if(
             base_decls.begin(), base_decls.end(),
             std::inserter(available_base_decls, available_base_decls.end()),
-            [this](const CXXRecordDecl* base_decl)
-            {
+            [this](const CXXRecordDecl *base_decl) {
                 return (available_decls_->find(base_decl->getCanonicalDecl())
-                            != available_decls_->end());
-            }
-        );
+                        != available_decls_->end());
+            });
         base_decls = available_base_decls;
     }
 
     // Convert each base class to a template object.
     // Since template objects are lazily-evaluated, this isn't expensive.
     std::vector<std::shared_ptr<CXXRecord>> base_vector;
-    for(const auto *base_decl : base_decls)
+    for (const auto *base_decl : base_decls)
     {
-        base_vector.push_back(
-            std::make_shared<CXXRecord>(
-                config_, base_decl));
+        base_vector.push_back(std::make_shared<CXXRecord>(config_, base_decl));
     }
 
     // Find and flag the last item.
@@ -281,8 +281,8 @@ CXXRecord::CXXRecord(
 
 ::mstch::node CXXRecord::scope()
 {
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config_.GetContext(), decl_->getCanonicalDecl(), true);
 
     return generateScope(config_, nns->getPrefix());
@@ -299,8 +299,8 @@ CXXRecord::CXXRecord(
 
 ::mstch::node CXXRecord::namespaceScope()
 {
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config_.GetContext(), decl_->getCanonicalDecl(), true);
 
     return generateNamespace(config_, nns->getPrefix());
@@ -308,8 +308,8 @@ CXXRecord::CXXRecord(
 
 ::mstch::node CXXRecord::classScope()
 {
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config_.GetContext(), decl_->getCanonicalDecl(), true);
 
     return generateScopeWithoutNamespace(config_, nns->getPrefix());
@@ -380,14 +380,13 @@ CXXRecord::CXXRecord(
         if (chimera::util::containsNonCopyableType(method_decl))
             continue;
 
-        const CXXConstructorDecl *constructor_decl =
-            cast<CXXConstructorDecl>(method_decl);
+        const CXXConstructorDecl *constructor_decl
+            = cast<CXXConstructorDecl>(method_decl);
         if (constructor_decl->isCopyOrMoveConstructor())
             continue;
 
         constructor_vector.push_back(
-            std::make_shared<Method>(
-                config_, method_decl, decl_));
+            std::make_shared<Method>(config_, method_decl, decl_));
     }
 
     // Find and flag the last item.
@@ -447,8 +446,8 @@ CXXRecord::CXXRecord(
 
         // Check if a return_value_policy can be generated for this function.
         if (::mstch::render("{{return_value_policy}}", method).empty()
-                && chimera::util::needsReturnValuePolicy(
-                    method_decl, method_decl->getReturnType()))
+            && chimera::util::needsReturnValuePolicy(
+                   method_decl, method_decl->getReturnType()))
         {
             // `needsReturnValuePolicy()` already prints an error message,
             // so just continue to the next method if we got here.
@@ -478,14 +477,16 @@ CXXRecord::CXXRecord(
     // Iterate through all methods searching for static ones.
     for (const ::mstch::node method_node : method_templates)
     {
-        // Resolve the static-ness and name of each function from method templates.
-        const auto method = boost::get<std::shared_ptr<::mstch::object>>(method_node);
+        // Resolve the static-ness and name of each function from method
+        // templates.
+        const auto method
+            = boost::get<std::shared_ptr<::mstch::object>>(method_node);
         const std::string name = boost::get<std::string>(method->at("name"));
         const bool is_static = boost::get<bool>(method->at("is_static"));
 
         // Throw a warning if a static and non-static method share a name.
-        if ((is_static_method.find(name) != is_static_method.end()) &&
-                (is_static_method[name] != is_static))
+        if ((is_static_method.find(name) != is_static_method.end())
+            && (is_static_method[name] != is_static))
         {
             std::cerr
                 << "Warning: Method '" << name << "' has ambiguous static and"
@@ -506,7 +507,7 @@ CXXRecord::CXXRecord(
 
     // Add all static method names to this list.
     ::mstch::array static_method_list;
-    for (auto const& entry : is_static_method)
+    for (auto const &entry : is_static_method)
     {
         if (entry.second)
             static_method_list.push_back(entry.first);
@@ -528,13 +529,12 @@ CXXRecord::CXXRecord(
         if (field_decl->getAccess() != AS_public)
             continue; // skip protected and private fields
 
-        if (!chimera::util::isCopyable(
-                config_.GetContext(), field_decl->getType()))
+        if (!chimera::util::isCopyable(config_.GetContext(),
+                                       field_decl->getType()))
             continue;
 
         field_vector.push_back(
-            std::make_shared<Field>(
-                config_, field_decl, decl_));
+            std::make_shared<Field>(config_, field_decl, decl_));
     }
 
     // Find and flag the last item.
@@ -569,13 +569,12 @@ CXXRecord::CXXRecord(
             continue;
 
         // Check if a return_value_policy can be generated for this function.
-        if (chimera::util::needsReturnValuePolicy(
-                static_field_decl, static_field_decl->getType()))
+        if (chimera::util::needsReturnValuePolicy(static_field_decl,
+                                                  static_field_decl->getType()))
             continue;
 
         static_field_vector.push_back(
-            std::make_shared<Variable>(
-                config_, static_field_decl, decl_));
+            std::make_shared<Variable>(config_, static_field_decl, decl_));
     }
 
     // Find and flag the last item.
@@ -589,14 +588,13 @@ CXXRecord::CXXRecord(
     return static_field_templates;
 }
 
-Enum::Enum(const ::chimera::CompiledConfiguration &config,
-           const EnumDecl *decl)
-: ClangWrapper(config, decl)
+Enum::Enum(const ::chimera::CompiledConfiguration &config, const EnumDecl *decl)
+  : ClangWrapper(config, decl)
 {
     register_methods(this, {
-        {"type", &Enum::type},
-        {"values", &Enum::values},
-    });
+                               {"type", &Enum::type},
+                               {"values", &Enum::values},
+                           });
 }
 
 ::mstch::node Enum::qualifiedName()
@@ -613,8 +611,8 @@ Enum::Enum(const ::chimera::CompiledConfiguration &config,
 
 ::mstch::node Enum::namespaceScope()
 {
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config_.GetContext(), decl_->getCanonicalDecl(), true);
 
     return generateNamespace(config_, nns->getPrefix());
@@ -622,8 +620,8 @@ Enum::Enum(const ::chimera::CompiledConfiguration &config,
 
 ::mstch::node Enum::classScope()
 {
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config_.GetContext(), decl_->getCanonicalDecl(), true);
 
     return generateScopeWithoutNamespace(config_, nns->getPrefix());
@@ -631,8 +629,8 @@ Enum::Enum(const ::chimera::CompiledConfiguration &config,
 
 ::mstch::node Enum::scope()
 {
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config_.GetContext(), decl_->getCanonicalDecl(), true);
 
     return generateScope(config_, nns->getPrefix());
@@ -658,8 +656,7 @@ Enum::Enum(const ::chimera::CompiledConfiguration &config,
         if (config_.IsSuppressed(constant_decl))
             continue;
         constant_vector.push_back(
-            std::make_shared<EnumConstant>(
-                config_, constant_decl, decl_));
+            std::make_shared<EnumConstant>(config_, constant_decl, decl_));
     }
 
     // Find and flag the last item.
@@ -676,8 +673,7 @@ Enum::Enum(const ::chimera::CompiledConfiguration &config,
 EnumConstant::EnumConstant(const ::chimera::CompiledConfiguration &config,
                            const EnumConstantDecl *decl,
                            const EnumDecl *enum_decl)
-: ClangWrapper(config, decl)
-, enum_decl_(enum_decl)
+  : ClangWrapper(config, decl), enum_decl_(enum_decl)
 {
     // Do nothing.
 }
@@ -691,21 +687,20 @@ EnumConstant::EnumConstant(const ::chimera::CompiledConfiguration &config,
     // fully resolve the qualified name, we can simply get it from appending
     // this value to the parent Enum's qualified name.
     auto enumeration = std::make_shared<Enum>(config_, enum_decl_);
-    return ::mstch::render("{{type}}", enumeration) + "::" +
-        decl_->getNameAsString();
+    return ::mstch::render("{{type}}", enumeration)
+           + "::" + decl_->getNameAsString();
 }
 
 Field::Field(const ::chimera::CompiledConfiguration &config,
-             const FieldDecl *decl,
-             const CXXRecordDecl *class_decl)
-: ClangWrapper(config, decl)
-, class_decl_(class_decl)
+             const FieldDecl *decl, const CXXRecordDecl *class_decl)
+  : ClangWrapper(config, decl), class_decl_(class_decl)
 {
-    register_methods(this, {
-        {"is_assignable", &Field::isAssignable},
-        {"is_copyable", &Field::isCopyable},
-        {"return_value_policy", &Field::returnValuePolicy},
-    });
+    register_methods(this,
+                     {
+                         {"is_assignable", &Field::isAssignable},
+                         {"is_copyable", &Field::isCopyable},
+                         {"return_value_policy", &Field::returnValuePolicy},
+                     });
 }
 
 ::mstch::node Field::isAssignable()
@@ -713,8 +708,7 @@ Field::Field(const ::chimera::CompiledConfiguration &config,
     if (const YAML::Node &node = decl_config_["is_assignable"])
         return node.as<std::string>();
 
-    return chimera::util::isAssignable(
-        config_.GetContext(), decl_->getType());
+    return chimera::util::isAssignable(config_.GetContext(), decl_->getType());
 }
 
 ::mstch::node Field::isCopyable()
@@ -722,8 +716,7 @@ Field::Field(const ::chimera::CompiledConfiguration &config,
     if (const YAML::Node &node = decl_config_["is_copyable"])
         return node.as<std::string>();
 
-    return chimera::util::isCopyable(
-        config_.GetContext(), decl_->getType());
+    return chimera::util::isCopyable(config_.GetContext(), decl_->getType());
 }
 
 ::mstch::node Field::returnValuePolicy()
@@ -733,13 +726,12 @@ Field::Field(const ::chimera::CompiledConfiguration &config,
         return node.as<std::string>();
 
     // Extract the value type of this field declaration.
-    const QualType value_qual_type =
-        chimera::util::getFullyQualifiedType(config_.GetContext(),
-                                             decl_->getType());
+    const QualType value_qual_type = chimera::util::getFullyQualifiedType(
+        config_.GetContext(), decl_->getType());
 
     // Next, check if a return_value_policy is defined on the value type.
-    if (const YAML::Node &type_node =
-            config_.GetType(value_qual_type)["return_value_policy"])
+    if (const YAML::Node &type_node
+        = config_.GetType(value_qual_type)["return_value_policy"])
         return type_node.as<std::string>();
 
     // Return an empty string if no return value policy exists.
@@ -751,31 +743,32 @@ Field::Field(const ::chimera::CompiledConfiguration &config,
     if (const YAML::Node &node = decl_config_["qualified_name"])
         return node.as<std::string>();
 
-    return chimera::util::getFullyQualifiedDeclTypeAsString(class_decl_) +
-        "::" + decl_->getNameAsString();
+    return chimera::util::getFullyQualifiedDeclTypeAsString(class_decl_)
+           + "::" + decl_->getNameAsString();
 }
 
 Function::Function(const ::chimera::CompiledConfiguration &config,
-                   const FunctionDecl *decl,
-                   const CXXRecordDecl *class_decl,
+                   const FunctionDecl *decl, const CXXRecordDecl *class_decl,
                    const int argument_limit)
-: ClangWrapper(config, decl)
-, class_decl_(class_decl)
-, argument_limit_(argument_limit)
+  : ClangWrapper(config, decl)
+  , class_decl_(class_decl)
+  , argument_limit_(argument_limit)
 {
-    register_methods(this, {
-        {"type", &Function::type},
-        {"overloads", &Function::overloads},
-        {"params", &Function::params},
-        {"params?", &Function::isNonFalse<Function, &Function::params>},
-        {"return_type", &Function::returnType},
-        {"return_value_policy", &Function::returnValuePolicy},
-        {"is_void", &Function::isVoid},
-        {"uses_defaults", &Function::usesDefaults},
-        {"is_template", &Function::isTemplate},
-        {"call", &Function::call},
-        {"qualified_call", &Function::qualifiedCall},
-    });
+    register_methods(
+        this,
+        {
+            {"type", &Function::type},
+            {"overloads", &Function::overloads},
+            {"params", &Function::params},
+            {"params?", &Function::isNonFalse<Function, &Function::params>},
+            {"return_type", &Function::returnType},
+            {"return_value_policy", &Function::returnValuePolicy},
+            {"is_void", &Function::isVoid},
+            {"uses_defaults", &Function::usesDefaults},
+            {"is_template", &Function::isTemplate},
+            {"call", &Function::call},
+            {"qualified_call", &Function::qualifiedCall},
+        });
 }
 
 ::mstch::node Function::scope()
@@ -799,8 +792,8 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
         pointer_type = config_.GetContext().getPointerType(decl_->getType());
     }
 
-    return chimera::util::getFullyQualifiedTypeName(
-        config_.GetContext(), pointer_type);
+    return chimera::util::getFullyQualifiedTypeName(config_.GetContext(),
+                                                    pointer_type);
 }
 
 ::mstch::node Function::overloads()
@@ -813,8 +806,7 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
     for (unsigned n_args = arg_range.first; n_args < arg_range.second; ++n_args)
     {
         overloads.push_back(
-            std::make_shared<Function>(
-                config_, decl_, class_decl_, n_args));
+            std::make_shared<Function>(config_, decl_, class_decl_, n_args));
     }
 
     // Add this function to its own list of overloads.
@@ -847,9 +839,8 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
 
         // Create a parameter template and add it to the parameter array.
         const ParmVarDecl *param_decl = decl_->getParamDecl(param_idx);
-        param_vector.push_back(
-            std::make_shared<Parameter>(
-                config_, param_decl, decl_, class_decl_, ss.str()));
+        param_vector.push_back(std::make_shared<Parameter>(
+            config_, param_decl, decl_, class_decl_, ss.str()));
     }
 
     // Find and flag the last item.
@@ -870,8 +861,8 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
         return node.as<std::string>();
 
     // Extract the return type of this function declaration.
-    return chimera::util::getFullyQualifiedTypeName(
-        config_.GetContext(), decl_->getReturnType());
+    return chimera::util::getFullyQualifiedTypeName(config_.GetContext(),
+                                                    decl_->getReturnType());
 }
 
 ::mstch::node Function::returnValuePolicy()
@@ -881,13 +872,12 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
         return node.as<std::string>();
 
     // Extract the return type of this function declaration.
-    const QualType return_qual_type =
-        chimera::util::getFullyQualifiedType(config_.GetContext(),
-                                             decl_->getReturnType());
+    const QualType return_qual_type = chimera::util::getFullyQualifiedType(
+        config_.GetContext(), decl_->getReturnType());
 
     // Next, check if a return_value_policy is defined on the return type.
-    if (const YAML::Node &type_node =
-            config_.GetType(return_qual_type)["return_value_policy"])
+    if (const YAML::Node &type_node
+        = config_.GetType(return_qual_type)["return_value_policy"])
         return type_node.as<std::string>();
 
     // Return an empty string if no return value policy exists.
@@ -910,8 +900,8 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
 
 ::mstch::node Function::classScope()
 {
-    return generateScopeWithoutNamespace(
-        config_, decl_->getEnclosingNamespaceContext());
+    return generateScopeWithoutNamespace(config_,
+                                         decl_->getEnclosingNamespaceContext());
 }
 
 ::mstch::node Function::usesDefaults()
@@ -928,7 +918,7 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
         return decl_->getQualifiedNameAsString();
 
     return chimera::util::getFullyQualifiedDeclTypeAsString(class_decl_)
-        + "::" + decl_->getNameAsString();
+           + "::" + decl_->getNameAsString();
 }
 
 ::mstch::node Function::qualifiedCall()
@@ -943,7 +933,7 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
         return decl_->getQualifiedNameAsString() + template_str;
 
     return chimera::util::getFullyQualifiedDeclTypeAsString(class_decl_)
-        + "::" + decl_->getNameAsString() + template_str;
+           + "::" + decl_->getNameAsString() + template_str;
 }
 
 ::mstch::node Function::call()
@@ -951,8 +941,8 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
     if (const YAML::Node &node = decl_config_["call"])
         return node.as<std::string>();
 
-    return decl_->getNameAsString() +
-        chimera::util::getTemplateParameterString(decl_);
+    return decl_->getNameAsString()
+           + chimera::util::getTemplateParameterString(decl_);
 }
 
 ::mstch::node Function::isTemplate()
@@ -961,15 +951,13 @@ Function::Function(const ::chimera::CompiledConfiguration &config,
 }
 
 Method::Method(const ::chimera::CompiledConfiguration &config,
-               const CXXMethodDecl *decl,
-               const CXXRecordDecl *class_decl)
-: Function(config, decl, class_decl)
-, method_decl_(decl)
+               const CXXMethodDecl *decl, const CXXRecordDecl *class_decl)
+  : Function(config, decl, class_decl), method_decl_(decl)
 {
     register_methods(this, {
-        {"is_const", &Method::isConst},
-        {"is_static", &Method::isStatic},
-    });
+                               {"is_const", &Method::isConst},
+                               {"is_static", &Method::isStatic},
+                           });
 }
 
 ::mstch::node Method::isConst()
@@ -984,34 +972,33 @@ Method::Method(const ::chimera::CompiledConfiguration &config,
 
 Namespace::Namespace(const ::chimera::CompiledConfiguration &config,
                      const NamespaceDecl *decl)
-: ClangWrapper(config, decl)
+  : ClangWrapper(config, decl)
 {
     // Do nothing.
 }
 
 ::mstch::node Namespace::scope()
 {
-    const NestedNameSpecifier *nns =
-        cling::utils::TypeName::CreateNestedNameSpecifier(
+    const NestedNameSpecifier *nns
+        = cling::utils::TypeName::CreateNestedNameSpecifier(
             config_.GetContext(), decl_->getCanonicalDecl());
 
     return generateScope(config_, nns->getPrefix());
 }
 
 Parameter::Parameter(const ::chimera::CompiledConfiguration &config,
-                     const ParmVarDecl *decl,
-                     const FunctionDecl *method_decl,
+                     const ParmVarDecl *decl, const FunctionDecl *method_decl,
                      const CXXRecordDecl *class_decl,
                      const std::string default_name)
-: ClangWrapper(config, decl)
-, method_decl_(method_decl)
-, class_decl_(class_decl)
-, default_name_(default_name)
+  : ClangWrapper(config, decl)
+  , method_decl_(method_decl)
+  , class_decl_(class_decl)
+  , default_name_(default_name)
 {
     register_methods(this, {
-        {"name", &Parameter::name},
-        {"type", &Parameter::type},
-    });
+                               {"name", &Parameter::name},
+                               {"type", &Parameter::type},
+                           });
 }
 
 ::mstch::node Parameter::name()
@@ -1021,14 +1008,13 @@ Parameter::Parameter(const ::chimera::CompiledConfiguration &config,
 
     // Ignore argument is part of a variadic function
     // (since it could be non-unique).
-    if (const auto template_decl =
-            method_decl_->getPrimaryTemplate())
+    if (const auto template_decl = method_decl_->getPrimaryTemplate())
         if (chimera::util::isVariadicFunctionTemplate(template_decl))
             return default_name_;
 
     // Use the "default_name" if the name would otherwise be empty
     std::string name = decl_->getNameAsString();
-    return (name.empty()) ? default_name_: name;
+    return (name.empty()) ? default_name_ : name;
 }
 
 ::mstch::node Parameter::type()
@@ -1036,19 +1022,17 @@ Parameter::Parameter(const ::chimera::CompiledConfiguration &config,
     if (const YAML::Node &node = decl_config_["type"])
         return node.as<std::string>();
 
-    return chimera::util::getFullyQualifiedTypeName(
-        config_.GetContext(), decl_->getType());
+    return chimera::util::getFullyQualifiedTypeName(config_.GetContext(),
+                                                    decl_->getType());
 }
 
 Variable::Variable(const ::chimera::CompiledConfiguration &config,
-                   const VarDecl *decl,
-                   const CXXRecordDecl *class_decl)
-: ClangWrapper(config, decl)
-, class_decl_(class_decl)
+                   const VarDecl *decl, const CXXRecordDecl *class_decl)
+  : ClangWrapper(config, decl), class_decl_(class_decl)
 {
     register_methods(this, {
-        {"is_assignable", &Variable::isAssignable},
-    });
+                               {"is_assignable", &Variable::isAssignable},
+                           });
 }
 
 ::mstch::node Variable::qualifiedName()
@@ -1060,7 +1044,7 @@ Variable::Variable(const ::chimera::CompiledConfiguration &config,
         return decl_->getQualifiedNameAsString();
 
     return chimera::util::getFullyQualifiedDeclTypeAsString(class_decl_)
-        + "::" + decl_->getNameAsString();
+           + "::" + decl_->getNameAsString();
 }
 
 ::mstch::node Variable::namespaceScope()
@@ -1083,8 +1067,7 @@ Variable::Variable(const ::chimera::CompiledConfiguration &config,
     if (const YAML::Node &node = decl_config_["is_assignable"])
         return node.as<std::string>();
 
-    return chimera::util::isAssignable(
-        config_.GetContext(), decl_->getType());
+    return chimera::util::isAssignable(config_.GetContext(), decl_->getType());
 }
 
 } // namespace mstch

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+if [ "$#" -lt 2 ]; then
+  echo "Usage: ./check_format.sh [<file> ...]" >&2
+  exit 0
+fi
+
+num_changes=`$1 -style=file -output-replacements-xml "${@:2}" | grep -c "<replacement "`
+
+if [ "$num_changes" = "0" ]; then
+  echo "Every file seems to comply with our code convention."
+  exit 0
+else
+  echo "Found" $num_changes "necessary changes."
+  exit 0
+fi


### PR DESCRIPTION
**Changes**
* Add `.clang-format` with configuration settings that are similar to the current codebase
* Add two custom targets:
  * `format`: format code
  * `check-format`: check code and exit 0 on success
* Setup CI to check code formatting using `check-format` target
* Format the code

Resolves #177 