### PR TITLE
Make binding tests as a custom target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,8 +152,5 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
 )
 
 # Enable unit testing by including the `test` subdirectory.
-option(BUILD_TESTING "Enable generation of Chimera build tests." ON)
-if(BUILD_TESTING)
-  enable_testing()
-  add_subdirectory(test)
-endif()
+enable_testing()
+add_subdirectory(test EXCLUDE_FROM_ALL)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,3 +74,16 @@ add_subdirectory(04_enumeration)
 add_subdirectory(05_variable)
 add_subdirectory(99_dart_example)
 add_subdirectory(regression)
+
+# Add custom target `binding_tests` to build all the tests as a single target
+get_property(chimera_pybind11_binding_tests GLOBAL
+  PROPERTY CHIMERA_PYBIND11_BINDING_TESTS
+)
+get_property(chimera_boost_python_binding_tests GLOBAL
+  PROPERTY CHIMERA_BOOST_PYTHON_BINDING_TESTS
+)
+add_custom_target(binding_tests
+  DEPENDS
+    ${chimera_pybind11_binding_tests}
+    ${chimera_boost_python_binding_tests}
+)

--- a/test/cmake/chimeraTestBoostPython.cmake
+++ b/test/cmake/chimeraTestBoostPython.cmake
@@ -115,4 +115,6 @@ function(chimera_add_binding_test_boost_python test_name)
       COMMAND ${CMAKE_COMMAND} -E copy ${test_name}*.so ${CMAKE_CURRENT_SOURCE_DIR}
     )
   endif()
+
+  set_property(GLOBAL APPEND PROPERTY CHIMERA_BOOST_PYTHON_BINDING_TESTS ${test_name})
 endfunction(chimera_add_binding_test_boost_python)

--- a/test/cmake/chimeraTestPybind11.cmake
+++ b/test/cmake/chimeraTestPybind11.cmake
@@ -114,4 +114,6 @@ function(chimera_add_binding_test_pybind11 test_name)
       COMMAND ${CMAKE_COMMAND} -E copy ${test_name}*.so ${CMAKE_CURRENT_SOURCE_DIR}
     )
   endif()
+
+  set_property(GLOBAL APPEND PROPERTY CHIMERA_PYBIND11_BINDING_TESTS ${test_name})
 endfunction(chimera_add_binding_test_pybind11)


### PR DESCRIPTION
Currently, tests are included in `all` target when `BUILD_TESTING` is on. If we use (custom) target for building tests, we can build the tests without rerunning CMake with different options.