### PR TITLE
Skip constructors with non-public param types

### DIFF
--- a/include/chimera/mstch.h
+++ b/include/chimera/mstch.h
@@ -68,6 +68,8 @@ public:
             });
     }
 
+    virtual ~ClangWrapper() = default;
+
     ::mstch::node last()
     {
         return last_;
@@ -211,6 +213,7 @@ public:
 
 protected:
     const std::set<const clang::CXXRecordDecl *> *available_decls_;
+    std::set<const clang::Type *> non_public_nested_decl_types_;
 };
 
 class Enum : public ClangWrapper<clang::EnumDecl>

--- a/include/chimera/mstch.h
+++ b/include/chimera/mstch.h
@@ -213,7 +213,6 @@ public:
 
 protected:
     const std::set<const clang::CXXRecordDecl *> *available_decls_;
-    std::set<const clang::Type *> non_public_nested_decl_types_;
 };
 
 class Enum : public ClangWrapper<clang::EnumDecl>

--- a/include/chimera/util.h
+++ b/include/chimera/util.h
@@ -238,6 +238,14 @@ bool needsReturnValuePolicy(const clang::NamedDecl *decl,
 std::pair<unsigned, unsigned> getFunctionArgumentRange(
     const clang::FunctionDecl *decl);
 
+/**
+ * Returns whether a method has a non-public type of parameter.
+ *
+ * This is possible when the class wants to hide the constructor from being
+ * called publicly.
+ */
+bool hasNonPublicParam(const clang::CXXMethodDecl *decl);
+
 } // namespace util
 } // namespace chimera
 

--- a/src/mstch.cpp
+++ b/src/mstch.cpp
@@ -233,6 +233,31 @@ CXXRecord::CXXRecord(const ::chimera::CompiledConfiguration &config,
             {"static_methods?",
              &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::methods>},
         });
+
+    // Collect non-public nested classes
+    for (auto d = decl_->decls_begin(); d != decl_->decls_end(); ++d)
+    {
+        if (CXXRecordDecl *C = dyn_cast<CXXRecordDecl>(*d))
+        {
+            if (C->getAccess() == AS_private)
+            {
+                std::cout << "C.name (private): " << C->getNameAsString()
+                          << std::endl;
+                non_public_nested_decl_types_.insert(C->getTypeForDecl());
+            }
+            else if (C->getAccess() == AS_protected)
+            {
+                std::cout << "C.name (protected): " << C->getNameAsString()
+                          << std::endl;
+                non_public_nested_decl_types_.insert(C->getTypeForDecl());
+            }
+            else
+            {
+                std::cout << "C.name (public): " << C->getNameAsString()
+                          << std::endl;
+            }
+        }
+    }
 }
 
 ::mstch::node CXXRecord::bases()

--- a/src/mstch.cpp
+++ b/src/mstch.cpp
@@ -415,6 +415,8 @@ CXXRecord::CXXRecord(const ::chimera::CompiledConfiguration &config,
             continue;
         if (method_decl->getAccess() != AS_public)
             continue; // skip protected and private members
+        if (chimera::util::hasNonPublicParam(method_decl))
+            continue;
         if (isa<CXXConversionDecl>(method_decl))
             continue;
         if (isa<CXXDestructorDecl>(method_decl))

--- a/src/mstch.cpp
+++ b/src/mstch.cpp
@@ -233,31 +233,6 @@ CXXRecord::CXXRecord(const ::chimera::CompiledConfiguration &config,
             {"static_methods?",
              &CXXRecord::isNonFalse<CXXRecord, &CXXRecord::methods>},
         });
-
-    // Collect non-public nested classes
-    for (auto d = decl_->decls_begin(); d != decl_->decls_end(); ++d)
-    {
-        if (CXXRecordDecl *C = dyn_cast<CXXRecordDecl>(*d))
-        {
-            if (C->getAccess() == AS_private)
-            {
-                std::cout << "C.name (private): " << C->getNameAsString()
-                          << std::endl;
-                non_public_nested_decl_types_.insert(C->getTypeForDecl());
-            }
-            else if (C->getAccess() == AS_protected)
-            {
-                std::cout << "C.name (protected): " << C->getNameAsString()
-                          << std::endl;
-                non_public_nested_decl_types_.insert(C->getTypeForDecl());
-            }
-            else
-            {
-                std::cout << "C.name (public): " << C->getNameAsString()
-                          << std::endl;
-            }
-        }
-    }
 }
 
 ::mstch::node CXXRecord::bases()
@@ -385,6 +360,8 @@ CXXRecord::CXXRecord(const ::chimera::CompiledConfiguration &config,
             continue;
         if (method_decl->getAccess() != AS_public)
             continue; // skip protected and private members
+        if (chimera::util::hasNonPublicParam(method_decl))
+            continue;
         if (method_decl->isDeleted())
             continue;
         if (!isa<CXXConstructorDecl>(method_decl))

--- a/test/examples/02_class/class.h
+++ b/test/examples/02_class/class.h
@@ -70,6 +70,18 @@ public:
   std::string m_name;
 };
 
+class MainClass
+{
+public:
+  MainClass() = default;
+
+  class NestedClass
+  {
+  public:
+    NestedClass() = default;
+  };
+};
+
 namespace detail {
 
 class ClassInDetail {};

--- a/test/examples/02_class/class.h
+++ b/test/examples/02_class/class.h
@@ -7,73 +7,75 @@
 namespace chimera_test {
 namespace nested_namespace {
 
-class Animal
+//class Animal
+//{
+//public:
+//  Animal();
+//  virtual ~Animal();
+//  virtual std::string type() const;
+//  virtual std::string pure_virtual_type() const = 0;
+//};
+
+//class Dog : public Animal
+//{
+//public:
+//  Dog();
+//  std::string type() const override;
+//  std::string pure_virtual_type() const override;
+
+//  static std::string static_type();
+//};
+
+//class Strong {};
+
+//class Husky : public Dog
+//{
+//public:
+//  Husky();
+//  std::string type() const override;
+//  std::string pure_virtual_type() const override;
+//};
+
+//class StrongHusky : public Dog, Strong
+//{
+//public:
+//  StrongHusky();
+//  std::string type() const override;
+//  std::string pure_virtual_type() const override;
+//};
+
+//class DefaultArguments
+//{
+//public:
+//  DefaultArguments() = default;
+//  int add(int i = 1, int j = 2) const;
+//};
+
+//class StaticFields
+//{
+//public:
+//  static std::string m_static_readwrite_type;
+//  static const std::string m_static_readonly_type;
+//  static std::string static_type();
+//};
+
+class NonPublicParamInConstructor
 {
+protected:
+    using ProtectedTypeDef = int;
+  struct ProtectedData{};
+  enum ProtectedEnum { PE_ONE };
+
 public:
-  Animal();
-  virtual ~Animal();
-  virtual std::string type() const;
-  virtual std::string pure_virtual_type() const = 0;
-};
-
-class Dog : public Animal
-{
-public:
-  Dog();
-  std::string type() const override;
-  std::string pure_virtual_type() const override;
-
-  static std::string static_type();
-};
-
-class Strong {};
-
-class Husky : public Dog
-{
-public:
-  Husky();
-  std::string type() const override;
-  std::string pure_virtual_type() const override;
-};
-
-class StrongHusky : public Dog, Strong
-{
-public:
-  StrongHusky();
-  std::string type() const override;
-  std::string pure_virtual_type() const override;
-};
-
-class DefaultArguments
-{
-public:
-  DefaultArguments() = default;
-  int add(int i = 1, int j = 2) const;
-};
-
-class StaticFields
-{
-public:
-  static std::string m_static_readwrite_type;
-  static const std::string m_static_readonly_type;
-  static std::string static_type();
-};
-
-class MainClass
-{
-public:
-  MainClass() = default;
-
-  class NestedClass
-  {
-  public:
-    NestedClass() = default;
-  };
+  NonPublicParamInConstructor(const ProtectedData&) {}
+  NonPublicParamInConstructor(ProtectedEnum) {}
+  NonPublicParamInConstructor(const std::string& name) : m_name(name) {}
+  std::string m_name;
 };
 
 namespace detail {
 
-class ClassInDetail {};
+//class ClassInDetail {};
 
 } // namespace detail
 

--- a/test/examples/02_class/class.h
+++ b/test/examples/02_class/class.h
@@ -7,75 +7,72 @@
 namespace chimera_test {
 namespace nested_namespace {
 
-//class Animal
-//{
-//public:
-//  Animal();
-//  virtual ~Animal();
-//  virtual std::string type() const;
-//  virtual std::string pure_virtual_type() const = 0;
-//};
+class Animal
+{
+public:
+ Animal();
+ virtual ~Animal();
+ virtual std::string type() const;
+ virtual std::string pure_virtual_type() const = 0;
+};
 
-//class Dog : public Animal
-//{
-//public:
-//  Dog();
-//  std::string type() const override;
-//  std::string pure_virtual_type() const override;
+class Dog : public Animal
+{
+public:
+ Dog();
+ std::string type() const override;
+ std::string pure_virtual_type() const override;
 
-//  static std::string static_type();
-//};
+ static std::string static_type();
+};
 
-//class Strong {};
+class Strong {};
 
-//class Husky : public Dog
-//{
-//public:
-//  Husky();
-//  std::string type() const override;
-//  std::string pure_virtual_type() const override;
-//};
+class Husky : public Dog
+{
+public:
+ Husky();
+ std::string type() const override;
+ std::string pure_virtual_type() const override;
+};
 
-//class StrongHusky : public Dog, Strong
-//{
-//public:
-//  StrongHusky();
-//  std::string type() const override;
-//  std::string pure_virtual_type() const override;
-//};
+class StrongHusky : public Dog, Strong
+{
+public:
+ StrongHusky();
+ std::string type() const override;
+ std::string pure_virtual_type() const override;
+};
 
-//class DefaultArguments
-//{
-//public:
-//  DefaultArguments() = default;
-//  int add(int i = 1, int j = 2) const;
-//};
+class DefaultArguments
+{
+public:
+ DefaultArguments() = default;
+ int add(int i = 1, int j = 2) const;
+};
 
-//class StaticFields
-//{
-//public:
-//  static std::string m_static_readwrite_type;
-//  static const std::string m_static_readonly_type;
-//  static std::string static_type();
-//};
+class StaticFields
+{
+public:
+ static std::string m_static_readwrite_type;
+ static const std::string m_static_readonly_type;
+ static std::string static_type();
+};
 
 class NonPublicParamInConstructor
 {
 protected:
-    using ProtectedTypeDef = int;
   struct ProtectedData{};
-  enum ProtectedEnum { PE_ONE };
 
 public:
   NonPublicParamInConstructor(const ProtectedData&) {}
-  NonPublicParamInConstructor(ProtectedEnum) {}
   NonPublicParamInConstructor(const std::string& name) : m_name(name) {}
   std::string m_name;
 };
 
 namespace detail {
 
-//class ClassInDetail {};
+class ClassInDetail {};
 
 } // namespace detail
 

--- a/test/examples/02_class/class.h
+++ b/test/examples/02_class/class.h
@@ -10,20 +10,20 @@ namespace nested_namespace {
 class Animal
 {
 public:
- Animal();
- virtual ~Animal();
- virtual std::string type() const;
- virtual std::string pure_virtual_type() const = 0;
+  Animal();
+  virtual ~Animal();
+  virtual std::string type() const;
+  virtual std::string pure_virtual_type() const = 0;
 };
 
 class Dog : public Animal
 {
 public:
- Dog();
- std::string type() const override;
- std::string pure_virtual_type() const override;
+  Dog();
+  std::string type() const override;
+  std::string pure_virtual_type() const override;
 
- static std::string static_type();
+  static std::string static_type();
 };
 
 class Strong {};
@@ -31,32 +31,32 @@ class Strong {};
 class Husky : public Dog
 {
 public:
- Husky();
- std::string type() const override;
- std::string pure_virtual_type() const override;
+  Husky();
+  std::string type() const override;
+  std::string pure_virtual_type() const override;
 };
 
 class StrongHusky : public Dog, Strong
 {
 public:
- StrongHusky();
- std::string type() const override;
- std::string pure_virtual_type() const override;
+  StrongHusky();
+  std::string type() const override;
+  std::string pure_virtual_type() const override;
 };
 
 class DefaultArguments
 {
 public:
- DefaultArguments() = default;
- int add(int i = 1, int j = 2) const;
+  DefaultArguments() = default;
+  int add(int i = 1, int j = 2) const;
 };
 
 class StaticFields
 {
 public:
- static std::string m_static_readwrite_type;
- static const std::string m_static_readonly_type;
- static std::string static_type();
+  static std::string m_static_readwrite_type;
+  static const std::string m_static_readonly_type;
+  static std::string static_type();
 };
 
 class NonPublicParamInConstructor

--- a/test/examples/02_class/class.py
+++ b/test/examples/02_class/class.py
@@ -40,6 +40,9 @@ class TestFunction(unittest.TestCase):
         self.assertEqual(py11.StaticFields.m_static_readwrite_type, 'new type')
         self.assertEqual(py11.StaticFields.static_type(), 'static type')
 
+        non_pub_param_in_ctr = py11.NonPublicParamInConstructor('Herb')
+        self.assertEqual(non_pub_param_in_ctr.m_name, 'Herb')
+
         # Check if the main class and the nested class can be created w/o errors
         mc = py11.MainClass()
         nc = py11.MainClass.NestedClass()
@@ -78,6 +81,9 @@ class TestFunction(unittest.TestCase):
         # boost.StaticFields.m_static_readwrite_type = 'new type'
         # self.assertEqual(boost.StaticFields.m_static_readwrite_type, 'new type')
         self.assertEqual(boost.StaticFields.static_type(), 'static type')
+
+        non_pub_param_in_ctr = boost.NonPublicParamInConstructor('Herb')
+        self.assertEqual(non_pub_param_in_ctr.m_name, 'Herb')
 
         # Check if the main class and the nested class can be created w/o errors
         mc = boost.MainClass()

--- a/test/test_emulator.cpp
+++ b/test/test_emulator.cpp
@@ -26,7 +26,7 @@ TEST(Emulator, GeneralOptions)
 }
 
 //==============================================================================
- TEST(Emulator, 01_Function)
+TEST(Emulator, 01_Function)
 {
     Emulator e;
     e.SetSource("01_function/function.h");

--- a/test/test_emulator.cpp
+++ b/test/test_emulator.cpp
@@ -26,14 +26,17 @@ TEST(Emulator, GeneralOptions)
 }
 
 //==============================================================================
-// TEST(Emulator, 01_Function)
-//{
-//    Emulator e;
-//    e.SetSource("01_function/function.h");
-//    e.SetConfigurationFile("01_function/function_pybind11.yaml");
-//    e.SetBinding("pybind11");
-//    EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
-//}
+ TEST(Emulator, 01_Function)
+{
+    Emulator e;
+    e.SetSource("01_function/function.h");
+    e.SetConfigurationFile("01_function/function_pybind11.yaml");
+    e.SetBinding("pybind11");
+
+    // EXPECT_EXIT is necessary to continue to run subsequent tests, but it
+    // doesn't stop at the breakpoints. For debugging use e.Run() instead.
+    EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
+}
 
 //==============================================================================
 TEST(Emulator, 02_Class)
@@ -42,5 +45,8 @@ TEST(Emulator, 02_Class)
     e.SetSource("02_class/class.h");
     e.SetConfigurationFile("02_class/class.yaml");
     e.SetBinding("pybind11");
+
+    // EXPECT_EXIT is necessary to continue to run subsequent tests, but it
+    // doesn't stop at the breakpoints. For debugging use e.Run() instead.
     EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
 }

--- a/test/test_emulator.cpp
+++ b/test/test_emulator.cpp
@@ -26,14 +26,14 @@ TEST(Emulator, GeneralOptions)
 }
 
 //==============================================================================
-TEST(Emulator, 01_Function)
-{
-    Emulator e;
-    e.SetSource("01_function/function.h");
-    e.SetConfigurationFile("01_function/function_pybind11.yaml");
-    e.SetBinding("pybind11");
-    e.Run();
-}
+// TEST(Emulator, 01_Function)
+//{
+//    Emulator e;
+//    e.SetSource("01_function/function.h");
+//    e.SetConfigurationFile("01_function/function_pybind11.yaml");
+//    e.SetBinding("pybind11");
+//    EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
+//}
 
 //==============================================================================
 TEST(Emulator, 02_Class)
@@ -42,5 +42,5 @@ TEST(Emulator, 02_Class)
     e.SetSource("02_class/class.h");
     e.SetConfigurationFile("02_class/class.yaml");
     e.SetBinding("pybind11");
-    e.Run();
+    EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
 }


### PR DESCRIPTION
Skip generating a constructor if it contains a parameter of which type access is non-public.

This is a rework of #200 to resolve #178.