### PR TITLE
Build with LLVM version equal to or greater than system version

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
     COMPILER: gcc
     BUILD_TYPE: Debug
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 3.6
+    LLVM_VERSION: 3.9
     PYTHON_VERSION: 3.5
     SUDO: sudo
   steps:
@@ -24,7 +24,7 @@ jobs:
     COMPILER: gcc
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 3.6
+    LLVM_VERSION: 3.9
     PYTHON_VERSION: 3.5
     SUDO: sudo
   steps:
@@ -38,7 +38,7 @@ jobs:
     COMPILER: gcc
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 3.9
+    LLVM_VERSION: 6.0
     PYTHON_VERSION: 3.6
     DOCKERFILE: Dockerfile.ubuntu-bionic
   steps:
@@ -52,7 +52,7 @@ jobs:
     COMPILER: gcc
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 3.9
+    LLVM_VERSION: 6.0
     PYTHON_VERSION: 3.6
     DOCKERFILE: Dockerfile.ubuntu-cosmic
   steps:

--- a/.ci/install_linux.sh
+++ b/.ci/install_linux.sh
@@ -12,7 +12,7 @@ $SUDO apt-get -y install "llvm-${LLVM_VERSION}-dev" "llvm-${LLVM_VERSION}-tools"
 
 # Install build tools
 $SUDO apt-get -y install \
-  build-essential  \
+  build-essential \
   cmake \
   curl \
   git \

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -8,11 +8,6 @@ fi
 mkdir build
 cd build
 
-# [DEBUG]
-dpkg -L llvm-${LLVM_VERSION}-dev
-dpkg -L llvm-${LLVM_VERSION}-tools
-test -e ${LLVM_DIR} && echo file exists || echo file not found
-
 if [ $BUILD_NAME = TRUSTY_GCC_DEBUG ]; then
   cmake "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" "-DLLVM_DIR=${LLVM_DIR}" "-DCODECOV=ON" ..
 else

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -2,11 +2,16 @@
 set -ex
 
 if [ "${OS_NAME}" = "linux" ]; then
-  export LLVM_DIR="/usr/share/llvm-${LLVM_VERSION}/cmake/"
+  export LLVM_DIR="/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/llvm/"
 fi
 
 mkdir build
 cd build
+
+# [DEBUG]
+dpkg -L llvm-${LLVM_VERSION}-dev
+dpkg -L llvm-${LLVM_VERSION}-tools
+test -e ${LLVM_DIR} && echo file exists || echo file not found
 
 if [ $BUILD_NAME = TRUSTY_GCC_DEBUG ]; then
   cmake "-DCMAKE_BUILD_TYPE=${BUILD_TYPE}" "-DLLVM_DIR=${LLVM_DIR}" "-DCODECOV=ON" ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         - BUILD_NAME=XENIAL_GCC_RELEASE
         - BUILD_TYPE=Release
         - COMPILER=GCC
-        - LLVM_VERSION=3.6
+        - LLVM_VERSION=3.9
         - PYTHON_VERSION=3.5
         - DOCKERFILE="Dockerfile.ubuntu-xenial"
       services: docker
@@ -56,7 +56,7 @@ matrix:
         - BUILD_NAME=BIONIC_GCC_RELEASE
         - BUILD_TYPE=Release
         - COMPILER=GCC
-        - LLVM_VERSION=3.9
+        - LLVM_VERSION=6.0
         - PYTHON_VERSION=3.6
         - DOCKERFILE="Dockerfile.ubuntu-bionic"
       services: docker

--- a/cmake/chimeraFindLLVM.cmake
+++ b/cmake/chimeraFindLLVM.cmake
@@ -1,29 +1,48 @@
-# We don't need anything special to find LLVM on Linux
 if(NOT APPLE)
+
+  # We don't need anything special to find LLVM on Linux
   find_package(LLVM REQUIRED CONFIG)
-  return()
+
+else()
+
+  # Find LLVM without LLVM_DIR
+  find_package(LLVM QUIET)
+
+  if(NOT LLVM_FOUND)
+    # Set LLVM_DIR using Homebrew
+    find_program(BREW_EXECUTABLE brew)
+    if(NOT BREW_EXECUTABLE)
+      message(FATAL_ERROR "Failed to find LLVM. Chimera now would like to find \
+        LLVM using Homebrew, but it's not installed. Please install Homebrew \
+        and install LLVM using Homebrew for building Chimera."
+      )
+    endif()
+    execute_process(COMMAND
+      ${BREW_EXECUTABLE} --prefix llvm
+      OUTPUT_VARIABLE LLVM_PREFIX
+    )
+    string(REGEX REPLACE "\n$" "" LLVM_PREFIX "${LLVM_PREFIX}")
+    set(LLVM_DIR "${LLVM_PREFIX}/lib/cmake/llvm")
+
+    # Find LLVM with LLVM_DIR
+    find_package(LLVM REQUIRED CONFIG)
+  endif()
+
 endif()
 
-# Find LLVM without LLVM_DIR
-find_package(LLVM QUIET)
-if(LLVM_FOUND)
-  return()
-endif()
-
-# Set LLVM_DIR using Homebrew
-find_program(BREW_EXECUTABLE brew)
-if(NOT BREW_EXECUTABLE)
-  message(FATAL_ERROR "Failed to find LLVM. Chimera now would like to find \
-    LLVM using Homebrew, but it's not installed. Please install Homebrew and \
-    install LLVM using Homebrew for building Chimera."
+# Check if LLVM is compatible with Chimera
+set(COMPATIBLE_LLVM_VERSIONS 3.6 3.9 6.0)
+set(LLVM_VERSION_MAJOR_MINOR ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR})
+set(FOUND_COMPATIBLE_LLVM FALSE)
+foreach(version ${COMPATIBLE_LLVM_VERSIONS})
+  if (${LLVM_VERSION_MAJOR_MINOR} VERSION_EQUAL ${version})
+    set(FOUND_COMPATIBLE_LLVM TRUE)
+    break()
+  endif()
+endforeach()
+if(NOT FOUND_COMPATIBLE_LLVM)
+  message(FATAL_ERROR "Found LLVM ${LLVM_VERSION}, but it's not compatible \
+    with Chimera. Please build Chimera with one of following LLVM \
+    versions: ${COMPATIBLE_LLVM_VERSIONS}"
   )
 endif()
-execute_process(COMMAND 
-  ${BREW_EXECUTABLE} --prefix llvm
-  OUTPUT_VARIABLE LLVM_PREFIX
-)
-string(REGEX REPLACE "\n$" "" LLVM_PREFIX "${LLVM_PREFIX}")
-set(LLVM_DIR "${LLVM_PREFIX}/lib/cmake/llvm")
-
-# Find LLVM with LLVM_DIR
-find_package(LLVM REQUIRED CONFIG)


### PR DESCRIPTION
* Trusty: Use 3.6. The system version is 3.4, but the minimum required version is 3.6.
* Xenial: Use 3.9. The system version is 3.8, but there is no available llvm-tool 3.8.
* Bionic: Use 6.0, which is the system version
* Cosmic: Use 6.0, which is the system version