### PR TITLE
Fix going to wrong directory while running rebuild target

### DIFF
--- a/cmake/chimeraFunctions.cmake
+++ b/cmake/chimeraFunctions.cmake
@@ -182,9 +182,10 @@ function(add_chimera_binding)
         DOWNLOAD_COMMAND ""
         INSTALL_COMMAND ""
         BUILD_COMMAND $(MAKE) "${binding_TARGET}_SOURCES"
+        COMMAND cd "${PROJECT_BINARY_DIR}"
         DEPENDS "${binding_TARGET}_SOURCES"
         SOURCE_DIR "${PROJECT_SOURCE_DIR}"
-        BUILD_IN_SOURCE 1
+        BINARY_DIR "${PROJECT_BINARY_DIR}"
     )
     set_target_properties("${binding_TARGET}_REBUILD" PROPERTIES EXCLUDE_FROM_ALL TRUE)
     add_dependencies("${binding_TARGET}" "${binding_TARGET}_REBUILD")

--- a/cmake/chimeraFunctions.cmake
+++ b/cmake/chimeraFunctions.cmake
@@ -181,9 +181,8 @@ function(add_chimera_binding)
     ExternalProject_Add("${binding_TARGET}_REBUILD"
         DOWNLOAD_COMMAND ""
         INSTALL_COMMAND ""
-        BUILD_COMMAND $(MAKE) "${binding_TARGET}_SOURCES"
-        COMMAND cd "${PROJECT_BINARY_DIR}"
         DEPENDS "${binding_TARGET}_SOURCES"
+        BUILD_COMMAND $(MAKE) "${binding_TARGET}_SOURCES"
         SOURCE_DIR "${PROJECT_SOURCE_DIR}"
         BINARY_DIR "${PROJECT_BINARY_DIR}"
     )

--- a/cmake/chimeraFunctions.cmake
+++ b/cmake/chimeraFunctions.cmake
@@ -178,11 +178,13 @@ function(add_chimera_binding)
     # For BUILD_COMMAND, '$(MAKE)' is used instead of 'make' to propagate the
     # make commands of the parent project to the child process.
     # (see: http://stackoverflow.com/a/33171336)
-    add_custom_target("${binding_TARGET}_REBUILD" DEPENDS "${binding_TARGET}_SOURCES")
-    add_custom_command(
-        OUTPUT "${binding_DESTINATION}/rebuild.txt"
-        COMMAND $(MAKE) "${binding_TARGET}_SOURCES"
-        VERBATIM
+    ExternalProject_Add("${binding_TARGET}_REBUILD"
+        DOWNLOAD_COMMAND ""
+        INSTALL_COMMAND ""
+        BUILD_COMMAND $(MAKE) "${binding_TARGET}_SOURCES"
+        DEPENDS "${binding_TARGET}_SOURCES"
+        SOURCE_DIR "${PROJECT_SOURCE_DIR}"
+        BUILD_IN_SOURCE 1
     )
     set_target_properties("${binding_TARGET}_REBUILD" PROPERTIES EXCLUDE_FROM_ALL TRUE)
     add_dependencies("${binding_TARGET}" "${binding_TARGET}_REBUILD")

--- a/cmake/chimeraFunctions.cmake
+++ b/cmake/chimeraFunctions.cmake
@@ -178,13 +178,11 @@ function(add_chimera_binding)
     # For BUILD_COMMAND, '$(MAKE)' is used instead of 'make' to propagate the
     # make commands of the parent project to the child process.
     # (see: http://stackoverflow.com/a/33171336)
-    ExternalProject_Add("${binding_TARGET}_REBUILD"
-        DOWNLOAD_COMMAND ""
-        INSTALL_COMMAND ""
-        BUILD_COMMAND $(MAKE) "${binding_TARGET}_SOURCES"
-        DEPENDS "${binding_TARGET}_SOURCES"
-        SOURCE_DIR "${PROJECT_SOURCE_DIR}"
-        BINARY_DIR "${PROJECT_BINARY_DIR}"
+    add_custom_target("${binding_TARGET}_REBUILD" DEPENDS "${binding_TARGET}_SOURCES")
+    add_custom_command(
+        OUTPUT "${binding_DESTINATION}/rebuild.txt"
+        COMMAND $(MAKE) "${binding_TARGET}_SOURCES"
+        VERBATIM
     )
     set_target_properties("${binding_TARGET}_REBUILD" PROPERTIES EXCLUDE_FROM_ALL TRUE)
     add_dependencies("${binding_TARGET}" "${binding_TARGET}_REBUILD")


### PR DESCRIPTION
Otherwise, this causes CMake error in downstream projects as:
```shell
[100%] Performing build step for 'dartpy_CHIMERA_REBUILD'
[100%] No install step for 'dartpy_CHIMERA_REBUILD'
[100%] Completed 'dartpy_CHIMERA_REBUILD'
[100%] Built target dartpy_CHIMERA_REBUILD
python/dartpy/CMakeFiles/binding.dir/build.make:54: CMakeFiles/binding.dir/progress.make: No such file or directory
make[3]: *** No rule to make target 'CMakeFiles/binding.dir/progress.make'.  Stop.
CMakeFiles/Makefile2:6246: recipe for target 'python/dartpy/CMakeFiles/binding.dir/all' failed
make[2]: *** [python/dartpy/CMakeFiles/binding.dir/all] Error 2
CMakeFiles/Makefile2:6258: recipe for target 'python/dartpy/CMakeFiles/binding.dir/rule' failed
make[1]: *** [python/dartpy/CMakeFiles/binding.dir/rule] Error 2
Makefile:1761: recipe for target 'binding' failed
make: *** [binding] Error 2

```

@psigen Was there a reason of using `ExternalProject_Add()` instead of `add_custom_target()`?