### PR TITLE
Make pybind11 test optional

### DIFF
--- a/test/examples/regression/issue228_template_type_alias/issue228_template_type_alias.py
+++ b/test/examples/regression/issue228_template_type_alias/issue228_template_type_alias.py
@@ -1,11 +1,17 @@
 import unittest
 
-import issue228_template_type_alias_pybind11.nested_namespace as py11
+try:
+    import issue228_template_type_alias_pybind11.nested_namespace as py11
+    has_pybind11 = True
+except:
+    has_pybind11 = False
 import issue228_template_type_alias_boost_python.nested_namespace as boost
 
 class TestFunction(unittest.TestCase):
 
     def test_function_py11(self):
+        if not has_pybind11:
+            return
         self.assertTrue(hasattr(py11, 'take_template_type_alias'))
 
     def test_function_bp(self):


### PR DESCRIPTION
This is necessary to build Chimera on PRL PPA. The pybind11 versions on Ubuntu package server (except Disco) are too old for Chimera.