### PR TITLE
Remove undefined member function (CXXRecord::heldType())

### DIFF
--- a/include/chimera/mstch.h
+++ b/include/chimera/mstch.h
@@ -202,7 +202,6 @@ public:
 
     ::mstch::node name() override;
     ::mstch::node qualifiedName() override;
-    ::mstch::node heldType();
 
     ::mstch::node constructors();
     ::mstch::node methods();


### PR DESCRIPTION
The definition of `CXXRecord::heldType()` was removed in [this commit](https://github.com/personalrobotics/chimera/commit/483674ffb300997950a4086a32becfbf5a57f7b7?w=1#diff-3f8c8328f0a509fbeb0a6d422bf8a85b) because "held_type" is simple text forwarding, which is supported by YAML. However, the declaration wasn't removed. This PR fixes it.