### PR TITLE
Fix inability to override methods

### DIFF
--- a/external/mstch/include/mstch/mstch.hpp
+++ b/external/mstch/include/mstch/mstch.hpp
@@ -29,10 +29,16 @@ class object_t {
   }
 
  protected:
+  ////////////////////////////
+  // MODIFIED FOR CHIMERA
+  ////////////////////////////
+
   template<class S>
   void register_methods(S* s, std::map<std::string,N(S::*)()> methods) {
     for(auto& item: methods)
-      this->methods.insert({item.first, std::bind(item.second, s)});
+      // This is a modification to the original mstch implementation that allows
+      // to override methods.
+      this->methods[item.first] = std::bind(item.second, s);
   }
 
   // This is a modification to the original mstch implementation that allows
@@ -40,6 +46,10 @@ class object_t {
   void register_lambda(std::string name, std::function<N()> func) {
     this->methods[name] = func;
   }
+
+  ////////////////////////////
+  // END MODIFIED FOR CHIMERA
+  ////////////////////////////
 
  private:
   std::map<std::string, std::function<N()>> methods;

--- a/include/chimera/mstch.h
+++ b/include/chimera/mstch.h
@@ -202,7 +202,6 @@ public:
 
     ::mstch::node name() override;
     ::mstch::node qualifiedName() override;
-    ::mstch::node heldType();
 
     ::mstch::node constructors();
     ::mstch::node methods();


### PR DESCRIPTION
This was originally introduced by https://github.com/personalrobotics/chimera/commit/ba8dd04203c75bdd8ef173c7033f5218acd56fff, but it's broken when merging the upstream in #132.