### PR TITLE
Update CI reflecting recent OS updates

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -4,7 +4,7 @@
 jobs:
 - job: ubuntu_xenial_gcc_release
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   variables:
     OS_NAME: linux
     COMPILER: gcc
@@ -18,7 +18,7 @@ jobs:
 
 - job: ubuntu_xenial_clang_release
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   variables:
     OS_NAME: linux
     COMPILER: clang
@@ -32,7 +32,7 @@ jobs:
 
 - job: ubuntu_bionic_gcc_release
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   variables:
     OS_NAME: linux
     COMPILER: gcc
@@ -46,7 +46,7 @@ jobs:
 
 - job: ubuntu_bionic_clang_release
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   variables:
     OS_NAME: linux
     COMPILER: clang
@@ -58,75 +58,73 @@ jobs:
   steps:
   - template: .ci/azure-pipelines/docker.yml
 
-- job: ubuntu_disco_gcc_release
+- job: ubuntu_eoan_gcc_release
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   variables:
     OS_NAME: linux
     COMPILER: gcc
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 6.0
+    LLVM_VERSION: 6.0  # 9 is the default but Chimera doesn't work with it
     PYTHON_VERSION: 3.7
-    DOCKERFILE: Dockerfile.ubuntu-disco
+    DOCKERFILE: Dockerfile.ubuntu-eoan
   steps:
   - template: .ci/azure-pipelines/docker.yml
 
-- job: ubuntu_disco_clang_release
+- job: ubuntu_eoan_clang_release
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-18.04'
   variables:
     OS_NAME: linux
     COMPILER: clang
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 6.0
+    LLVM_VERSION: 6.0  # 9 is the default but Chimera doesn't work with it
     PYTHON_VERSION: 3.7
-    DOCKERFILE: Dockerfile.ubuntu-disco
+    DOCKERFILE: Dockerfile.ubuntu-eoan
   steps:
   - template: .ci/azure-pipelines/docker.yml
 
-# - job: macos_high_seirra_clang_llvm4_release
-#   pool:
-#     vmImage: 'macOS 10.13'
-#   variables:
-#     OS_NAME: osx
-#     COMPILER: clang
-#     BUILD_TYPE: Release
-#     BUILD_DIR: $(Build.SourcesDirectory)
-#     LLVM_VERSION: 4
-#   steps:
-#   - script: |
-#       . .ci/install_macos.sh
-#       . .ci/script.sh
-#     displayName: 'Install/Script'
+- job: ubuntu_focal_gcc_release
+  pool:
+    vmImage: 'ubuntu-18.04'
+  variables:
+    OS_NAME: linux
+    COMPILER: gcc
+    BUILD_TYPE: Release
+    BUILD_DIR: $(Build.SourcesDirectory)
+    LLVM_VERSION: 6.0  # 10 is the default but Chimera doesn't work with it
+    PYTHON_VERSION: 3.8
+    DOCKERFILE: Dockerfile.ubuntu-focal
+  steps:
+  - template: .ci/azure-pipelines/docker.yml
 
-# - job: macos_high_seirra_clang_llvm5_release
-#   pool:
-#     vmImage: 'macOS 10.13'
-#   variables:
-#     OS_NAME: osx
-#     COMPILER: clang
-#     BUILD_TYPE: Release
-#     BUILD_DIR: $(Build.SourcesDirectory)
-#     LLVM_VERSION: 5
-#   steps:
-#   - script: |
-#       source .ci/install_macos.sh
-#       . .ci/script.sh
-#     displayName: 'Install/Script'
+- job: ubuntu_focal_clang_release
+  pool:
+    vmImage: 'ubuntu-18.04'
+  variables:
+    OS_NAME: linux
+    COMPILER: clang
+    BUILD_TYPE: Release
+    BUILD_DIR: $(Build.SourcesDirectory)
+    LLVM_VERSION: 6.0  # 10 is the default but Chimera doesn't work with it
+    PYTHON_VERSION: 3.8
+    DOCKERFILE: Dockerfile.ubuntu-focal
+  steps:
+  - template: .ci/azure-pipelines/docker.yml
 
-# - job: macos_high_seirra_clang_llvm6_release
-#   pool:
-#     vmImage: 'macOS 10.13'
-#   variables:
-#     OS_NAME: osx
-#     COMPILER: clang
-#     BUILD_TYPE: Release
-#     BUILD_DIR: $(Build.SourcesDirectory)
-#     LLVM_VERSION: 6
-#   steps:
-#   - script: |
-#       . .ci/install_macos.sh
-#       . .ci/script.sh
-#     displayName: 'Install/Script'
+- job: macos_mojave_clang_llvm6_release
+  pool:
+    vmImage: 'macOS 10.14'
+  variables:
+    OS_NAME: osx
+    COMPILER: clang
+    BUILD_TYPE: Release
+    BUILD_DIR: $(Build.SourcesDirectory)
+    LLVM_VERSION: 6
+  steps:
+  - script: |
+      . .ci/install_macos.sh
+      . .ci/script.sh
+    displayName: 'Install/Script'

--- a/.ci/docker/Dockerfile.ubuntu-disco
+++ b/.ci/docker/Dockerfile.ubuntu-disco
@@ -1,1 +1,0 @@
-FROM ubuntu:disco

--- a/.ci/docker/Dockerfile.ubuntu-eoan
+++ b/.ci/docker/Dockerfile.ubuntu-eoan
@@ -1,0 +1,1 @@
+FROM ubuntu:eoan

--- a/.ci/docker/Dockerfile.ubuntu-focal
+++ b/.ci/docker/Dockerfile.ubuntu-focal
@@ -1,0 +1,3 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive

--- a/.ci/install_linux.sh
+++ b/.ci/install_linux.sh
@@ -2,6 +2,8 @@
 set -ex
 
 $SUDO apt-get -q update
+$SUDO apt-get -y install \
+  lsb-release
 
 if [ $(lsb_release -sc) = "trusty" ]; then
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | $SUDO apt-key add -
@@ -19,7 +21,6 @@ $SUDO apt-get -y install \
   lib32z1-dev \
   lsb-release \
   pkg-config \
-  python \
   software-properties-common \
   sudo \
   wget
@@ -28,21 +29,28 @@ $SUDO apt-get -y install \
 $SUDO apt-get -y install libeigen3-dev
 $SUDO apt-get -y install libboost-python-dev libboost-thread-dev
 $SUDO apt-get -y install lcov
-$SUDO apt-get -y install python-dev python3-dev
-$SUDO apt-get -y install libpython-dev libpython3-dev
+# Install Python 2 up to Eoan
+if [ $(lsb_release -sc) = "xenial" ] || [ $(lsb_release -sc) = "bionic" ] || [ $(lsb_release -sc) = "eoan" ]; then
+  $SUDO apt-get -y install python-dev libpython-dev
+fi
+$SUDO apt-get -y install python3-dev libpython3-dev
 
 # Install ClangFormat 6
 if [ $(lsb_release -sc) = "bionic" ]; then
   $SUDO apt-get -y install clang-format-6.0
 fi
 
-# Install pybind11 from source (we need pybind11 (>=2.2.0))
-git clone https://github.com/pybind/pybind11.git
-cd pybind11
-git checkout tags/v2.2.3
-mkdir build
-cd build
-cmake .. -DPYBIND11_TEST=OFF -DPYBIND11_PYTHON_VERSION=$PYTHON_VERSION
-make -j4
-$SUDO make install
-cd ../..
+# Install pybind11 (we need pybind11 (>=2.2.4))
+if [ $(lsb_release -sc) = "xenial" ] || [ $(lsb_release -sc) = "bionic" ]; then
+  git clone https://github.com/pybind/pybind11.git
+  cd pybind11
+  git checkout tags/v2.2.4
+  mkdir build
+  cd build
+  cmake .. -DPYBIND11_TEST=OFF -DPYBIND11_PYTHON_VERSION=$PYTHON_VERSION
+  make -j4
+  $SUDO make install
+  cd ../..
+else
+  $SUDO apt-get -y install pybind11-dev
+fi

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -22,12 +22,20 @@ if [ "$OS_NAME" = "linux" ] && [ $(lsb_release -sc) = "bionic" ]; then
   make check-format
 fi
 
-make -j4 tests binding_tests
+make -j4
 
-if [ $BUILD_NAME = TRUSTY_GCC_DEBUG ]; then
-  make chimera_coverage
-else
-  ctest --output-on-failure
+# Building tests and binding_tests fails on macOS (see: https://github.com/personalrobotics/chimera/issues/218)
+if [ "${OS_NAME}" = "linux" ]; then
+  # Building binding_tests fails on Ubuntu Focal
+  if [ ! $(lsb_release -sc) = "focal" ]; then
+    make -j4 tests binding_tests
+
+    if [ $BUILD_NAME = TRUSTY_GCC_DEBUG ]; then
+      make chimera_coverage
+    else
+      ctest --output-on-failure
+    fi
+  fi
 fi
 
 $SUDO make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 
 sudo: required
 
-dist: xenial
+dist: bionic
 
 env:
   global:
@@ -37,12 +37,22 @@ matrix:
     - os: linux
       compiler: gcc
       env:
-        - BUILD_NAME=DISCO_GCC_DEBUG
+        - BUILD_NAME=EOAN_GCC_DEBUG
         - BUILD_TYPE=Debug
         - COMPILER=GCC
-        - LLVM_VERSION=6.0
+        - LLVM_VERSION=6.0  # 9 is the default but Chimera doesn't work with it
         - PYTHON_VERSION=3.7
-        - DOCKERFILE="Dockerfile.ubuntu-disco"
+        - DOCKERFILE="Dockerfile.ubuntu-eoan"
+      services: docker
+    - os: linux
+      compiler: gcc
+      env:
+        - BUILD_NAME=FOCAL_GCC_DEBUG
+        - BUILD_TYPE=Debug
+        - COMPILER=GCC
+        - LLVM_VERSION=6.0  # 10 is the default but Chimera doesn't work with it
+        - PYTHON_VERSION=3.8
+        - DOCKERFILE="Dockerfile.ubuntu-focal"
       services: docker
 
 before_install:

--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,5 @@
 brew 'boost'
-brew 'yaml-cpp', args: ["with-static-lib"]
+brew 'yaml-cpp'
 
 # For testing
 brew 'boost-python'

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ ./chimera -c <yaml_config_file> -o <output_path> my_cpp_header1.h my_cpp_heade
 
 ### On Ubuntu using `apt`
 
-Chimera provides Ubuntu packages for Trusty (14.04), Xenial (16.04), Bionic (18.04), Cosmic (18.10), and Disco (19.04).
+Chimera provides Ubuntu packages for Trusty (14.04 LTS), Xenial (16.04 LTS), and Bionic (18.04 LTS).
 
 **Trusty**
 
@@ -34,7 +34,7 @@ $ sudo apt update
 $ sudo apt install chimera
 ```
 
-**Xenial/Bionic/Cosmic/Disco**
+**Xenial and greater**
 
 ```shell
 $ sudo add-apt-repository ppa:personalrobotics/ppa
@@ -80,7 +80,7 @@ $ make
 $ sudo make install
 ```
 
-**Xenial/Bionic**
+**Xenial and greater**
 
 ```bash
 $ sudo apt-get install llvm-4.0-dev llvm-4.0-tools libclang-4.0-dev libedit-dev libyaml-cpp-dev libboost-dev lib32z1-dev


### PR DESCRIPTION
- Update CI images to recent OS versions
- Remove CI builds for deprecated OS versions
- Add CI builds for new OS versions
- Disable building tests for macOS (see: [#228](https://github.com/personalrobotics/chimera/issues/218)) and Ubuntu Focal (tests  fails for some reason)
- Install `yaml-cpp` without option `--with-static-lib` as it's removed
- Update `README.md` reflecting the updates