### PR TITLE
Workaround for segfault with LLVM >= 7

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
   steps:
   - template: .ci/azure-pipelines/docker.yml
 
-- job: ubuntu_eoan_gcc_release
+- job: ubuntu_eoan_gcc_release_llvm6
   pool:
     vmImage: 'ubuntu-18.04'
   variables:
@@ -67,6 +67,34 @@ jobs:
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
     LLVM_VERSION: 6.0  # 9 is the default but Chimera doesn't work with it
+    PYTHON_VERSION: 3.7
+    DOCKERFILE: Dockerfile.ubuntu-eoan
+  steps:
+  - template: .ci/azure-pipelines/docker.yml
+
+- job: ubuntu_eoan_gcc_release_llvm8
+  pool:
+    vmImage: 'ubuntu-18.04'
+  variables:
+    OS_NAME: linux
+    COMPILER: gcc
+    BUILD_TYPE: Release
+    BUILD_DIR: $(Build.SourcesDirectory)
+    LLVM_VERSION: 8.0  # 9 is the default but Chimera doesn't work with it
+    PYTHON_VERSION: 3.7
+    DOCKERFILE: Dockerfile.ubuntu-eoan
+  steps:
+  - template: .ci/azure-pipelines/docker.yml
+
+- job: ubuntu_eoan_gcc_release_llvm9
+  pool:
+    vmImage: 'ubuntu-18.04'
+  variables:
+    OS_NAME: linux
+    COMPILER: gcc
+    BUILD_TYPE: Release
+    BUILD_DIR: $(Build.SourcesDirectory)
+    LLVM_VERSION: 9.0
     PYTHON_VERSION: 3.7
     DOCKERFILE: Dockerfile.ubuntu-eoan
   steps:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
     COMPILER: gcc
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 8.0  # 9 is the default but Chimera doesn't work with it
+    LLVM_VERSION: 8  # 9 is the default but Chimera doesn't work with it
     PYTHON_VERSION: 3.7
     DOCKERFILE: Dockerfile.ubuntu-eoan
   steps:
@@ -94,7 +94,7 @@ jobs:
     COMPILER: gcc
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 9.0
+    LLVM_VERSION: 9
     PYTHON_VERSION: 3.7
     DOCKERFILE: Dockerfile.ubuntu-eoan
   steps:

--- a/cmake/chimeraFindLLVM.cmake
+++ b/cmake/chimeraFindLLVM.cmake
@@ -32,7 +32,7 @@ endif()
 
 # Check if LLVM is compatible with Chimera
 # LLVM >= 7 is disabled: https://github.com/personalrobotics/chimera/issues/222
-set(COMPATIBLE_LLVM_VERSIONS 3.6 3.9 6.0)
+set(COMPATIBLE_LLVM_VERSIONS 3.6 3.9 6.0 8.0 9.0 10.0)
 set(LLVM_VERSION_MAJOR_MINOR ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR})
 set(FOUND_COMPATIBLE_LLVM FALSE)
 foreach(version ${COMPATIBLE_LLVM_VERSIONS})

--- a/cmake/chimeraFindLLVM.cmake
+++ b/cmake/chimeraFindLLVM.cmake
@@ -31,7 +31,9 @@ else()
 endif()
 
 # Check if LLVM is compatible with Chimera
-# LLVM >= 7 is disabled: https://github.com/personalrobotics/chimera/issues/222
+#
+# Note that LLVM >= 7 causes memory leaks in chimera::util::resolveDeclaration()
+# See https://github.com/personalrobotics/chimera/issues/222
 set(COMPATIBLE_LLVM_VERSIONS 3.6 3.9 6.0 8.0 9.0 10.0)
 set(LLVM_VERSION_MAJOR_MINOR ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR})
 set(FOUND_COMPATIBLE_LLVM FALSE)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -116,10 +116,17 @@ const NamedDecl *resolveDeclaration(CompilerInstance *ci,
     // Create a new parser to handle this type parsing.
     Preprocessor &preprocessor = ci->getPreprocessor();
     Sema &sema = ci->getSema();
+#if LLVM_VERSION_AT_LEAST(7, 0, 0)
+    // TODO: Since LLVM 7, segfault occurs when the destructor of clang::Parser
+    // is called. Following code workaround the segfault by not destructing
+    // the clang::Parser instance, which leads to memory leak. This should be
+    // fixed. See https://github.com/personalrobotics/chimera/issues/222
     auto *parser_ptr
         = new Parser(preprocessor, sema, /* SkipFunctionBodies = */ false);
     Parser &parser = *parser_ptr;
-    // Parser parser(preprocessor, sema, /* SkipFunctionBodies = */ false);
+#else
+    Parser parser(preprocessor, sema, /* SkipFunctionBodies = */ false);
+#endif
 
     // Set up the preprocessor to only care about incrementally handling type.
     preprocessor.getDiagnostics().setIgnoreAllWarnings(true);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -116,7 +116,10 @@ const NamedDecl *resolveDeclaration(CompilerInstance *ci,
     // Create a new parser to handle this type parsing.
     Preprocessor &preprocessor = ci->getPreprocessor();
     Sema &sema = ci->getSema();
-    Parser parser(preprocessor, sema, /* SkipFunctionBodies = */ false);
+    auto *parser_ptr
+        = new Parser(preprocessor, sema, /* SkipFunctionBodies = */ false);
+    Parser &parser = *parser_ptr;
+    // Parser parser(preprocessor, sema, /* SkipFunctionBodies = */ false);
 
     // Set up the preprocessor to only care about incrementally handling type.
     preprocessor.getDiagnostics().setIgnoreAllWarnings(true);


### PR DESCRIPTION
I wasn't able to find the root cause, but build with LLVM >= 7 causes segfault when the destructor of `clang::Parser` is called in `chimera::util::resolveDeclaration`.

This PR workaround by not destructing `clang::Parser` for LLVM >= 7. Since this workaround leads to a memory leak, this should be fixed once we figure out the root cause.