### PR TITLE
Disable parallel build on CI to avoid build failures

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -28,6 +28,12 @@ make -j4
 if [ "${OS_NAME}" = "linux" ]; then
   # Building binding_tests fails on Ubuntu Focal
   if [ ! $(lsb_release -sc) = "focal" ]; then
+    # Parallel build for examples is disabled by
+    # https://github.com/personalrobotics/chimera/pull/274
+    # because it seems to cause missing intermediate target. Here are examples of the
+    # build failures:
+    # - https://travis-ci.org/github/personalrobotics/chimera/jobs/671315806#L2226-L2301
+    # - https://travis-ci.org/github/personalrobotics/chimera/jobs/671301082#L2523-L2573
     make tests binding_tests
 
     if [ $BUILD_NAME = TRUSTY_GCC_DEBUG ]; then

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -28,7 +28,7 @@ make -j4
 if [ "${OS_NAME}" = "linux" ]; then
   # Building binding_tests fails on Ubuntu Focal
   if [ ! $(lsb_release -sc) = "focal" ]; then
-    make -j4 tests binding_tests
+    make tests binding_tests
 
     if [ $BUILD_NAME = TRUSTY_GCC_DEBUG ]; then
       make chimera_coverage


### PR DESCRIPTION
It seems CI builds irregularly fail due to parallel build. I've been re-running every failed CI tests whenever they failed. Not sure if this is related to #212.