### PR TITLE
Remove exit() from emulator

### DIFF
--- a/src/chimera.cpp
+++ b/src/chimera.cpp
@@ -87,7 +87,7 @@ int run(int argc, const char **argv)
             std::cout << "Chimera " << CHIMERA_MAJOR_VERSION << "."
                       << CHIMERA_MINOR_VERSION << "." << CHIMERA_PATCH_VERSION
                       << "\n\n";
-            exit(0);
+            return 0;
         }
     }
 

--- a/test/emulator.cpp
+++ b/test/emulator.cpp
@@ -61,7 +61,7 @@ Emulator::Emulator()
 }
 
 //==============================================================================
-void Emulator::Run()
+bool Emulator::Run()
 {
     std::vector<std::string> args;
     args.push_back("");
@@ -92,13 +92,11 @@ void Emulator::Run()
     }
 
     std::vector<const char *> argv = convertArgs(args);
-    chimera::run(static_cast<int>(argv.size()), argv.data());
-
-    exit(0);
+    return chimera::run(static_cast<int>(argv.size()), argv.data()) == 0;
 }
 
 //==============================================================================
-void Emulator::Run(const std::string &args)
+bool Emulator::Run(const std::string &args)
 {
     std::vector<std::string> args_splits = split(args, " ");
     std::vector<const char *> argv;
@@ -106,48 +104,40 @@ void Emulator::Run(const std::string &args)
     for (auto &arg : args_splits)
         argv.push_back(arg.data());
 
-    chimera::run(static_cast<int>(argv.size()), argv.data());
-
-    exit(0);
+    return chimera::run(static_cast<int>(argv.size()), argv.data()) == 0;
 }
 
 //==============================================================================
-void Emulator::RunHelp()
+bool Emulator::RunHelp()
 {
     int argc = 2;
     std::vector<const char *> argv;
     argv.push_back("");
     argv.push_back("--help");
 
-    chimera::run(argc, argv.data());
-
-    exit(0);
+    return chimera::run(argc, argv.data()) == 0;
 }
 
 //==============================================================================
-void Emulator::RunHelpList()
+bool Emulator::RunHelpList()
 {
     int argc = 2;
     std::vector<const char *> argv;
     argv.push_back("");
     argv.push_back("--help-list");
 
-    chimera::run(argc, argv.data());
-
-    exit(0);
+    return chimera::run(argc, argv.data()) == 0;
 }
 
 //==============================================================================
-void Emulator::RunVersion()
+bool Emulator::RunVersion()
 {
     int argc = 2;
     std::vector<const char *> argv;
     argv.push_back("");
     argv.push_back("--version");
 
-    chimera::run(argc, argv.data());
-
-    exit(0);
+    return chimera::run(argc, argv.data()) == 0;
 }
 
 //==============================================================================

--- a/test/emulator.h
+++ b/test/emulator.h
@@ -12,13 +12,13 @@ class Emulator
 public:
     Emulator();
 
-    void Run();
+    bool Run();
 
-    static void Run(const std::string &args);
+    static bool Run(const std::string &args);
 
-    static void RunHelp();
-    static void RunHelpList();
-    static void RunVersion();
+    static bool RunHelp();
+    static bool RunHelpList();
+    static bool RunVersion();
 
     void SetSource(const std::string &filename);
     void SetSources(const std::vector<std::string> &filenames);

--- a/test/test_emulator.cpp
+++ b/test/test_emulator.cpp
@@ -12,15 +12,17 @@ TEST(Emulator, GeneralOptions)
 {
     testing::internal::CaptureStdout();
 
+    // EXPECT_EXIT is used to continue running the rest of the tests. This is
+    // because ClangTool exits right after it prints help. Note that this makes
+    // the breakpoints don't work in executing the test s in EXPECT_EXIT.
     EXPECT_EXIT(Emulator::RunHelp(), ::testing::ExitedWithCode(0), ".*");
     EXPECT_EXIT(Emulator::Run("--help"), ::testing::ExitedWithCode(0), ".*");
-
     EXPECT_EXIT(Emulator::RunHelpList(), ::testing::ExitedWithCode(0), ".*");
     EXPECT_EXIT(Emulator::Run("--help-list"), ::testing::ExitedWithCode(0),
                 ".*");
 
-    EXPECT_EXIT(Emulator::RunVersion(), ::testing::ExitedWithCode(0), ".*");
-    EXPECT_EXIT(Emulator::Run("--version"), ::testing::ExitedWithCode(0), ".*");
+    EXPECT_TRUE(Emulator::RunVersion());
+    EXPECT_TRUE(Emulator::Run("--version"));
 
     std::string output = testing::internal::GetCapturedStdout();
 }
@@ -33,9 +35,7 @@ TEST(Emulator, 01_Function)
     e.SetConfigurationFile("01_function/function_pybind11.yaml");
     e.SetBinding("pybind11");
 
-    // EXPECT_EXIT is necessary to continue to run subsequent tests, but it
-    // doesn't stop at the breakpoints. For debugging use e.Run() instead.
-    EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
+    EXPECT_TRUE(e.Run());
 }
 
 //==============================================================================
@@ -46,9 +46,7 @@ TEST(Emulator, 02_Class)
     e.SetConfigurationFile("02_class/class.yaml");
     e.SetBinding("pybind11");
 
-    // EXPECT_EXIT is necessary to continue to run subsequent tests, but it
-    // doesn't stop at the breakpoints. For debugging use e.Run() instead.
-    EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
+    EXPECT_TRUE(e.Run());
 }
 
 //==============================================================================
@@ -59,9 +57,7 @@ TEST(Emulator, 04_Enumeration)
     e.SetConfigurationFile("04_enumeration/enumeration.yaml");
     e.SetBinding("pybind11");
 
-    // EXPECT_EXIT is necessary to continue to run subsequent tests, but it
-    // doesn't stop at the breakpoints. For debugging use e.Run() instead.
-    EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
+    EXPECT_TRUE(e.Run());
 }
 
 //==============================================================================
@@ -72,9 +68,7 @@ TEST(Emulator, 20_Eigen)
     e.SetConfigurationFile("20_eigen/eigen_pybind11.yaml");
     e.SetBinding("pybind11");
 
-    // EXPECT_EXIT is necessary to continue to run subsequent tests, but it
-    // doesn't stop at the breakpoints. For debugging use e.Run() instead.
-    EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
+    EXPECT_TRUE(e.Run());
 }
 
 //==============================================================================
@@ -89,7 +83,5 @@ TEST(Emulator, issue228)
         "issue228_template_type_alias_pybind11.yaml");
     e.SetBinding("pybind11");
 
-    // EXPECT_EXIT is necessary to continue to run subsequent tests, but it
-    // doesn't stop at the breakpoints. For debugging use e.Run() instead.
-    EXPECT_EXIT(e.Run(), ::testing::ExitedWithCode(0), ".*");
+    EXPECT_TRUE(e.Run());
 }


### PR DESCRIPTION
This PR makes easier to debugging for the unit tests as we can use breakpoints without modifying the test code.