### PR TITLE
Suppress #148: Skip generating binding for lambda function

### DIFF
--- a/include/chimera/mstch.h
+++ b/include/chimera/mstch.h
@@ -207,6 +207,7 @@ public:
               = nullptr);
 
     ::mstch::node bases();
+    std::string typeAsString();
     ::mstch::node type();
     ::mstch::node namespaceScope() override;
     ::mstch::node classScope() override;

--- a/src/mstch.cpp
+++ b/src/mstch.cpp
@@ -294,13 +294,18 @@ CXXRecord::CXXRecord(const ::chimera::CompiledConfiguration &config,
     return generateScope(config_, nns->getPrefix());
 }
 
-::mstch::node CXXRecord::type()
+std::string CXXRecord::typeAsString()
 {
     if (const YAML::Node node = decl_config_["type"])
         return node.as<std::string>();
 
     return chimera::util::getFullyQualifiedTypeName(
         config_.GetContext(), QualType(decl_->getTypeForDecl(), 0));
+}
+
+::mstch::node CXXRecord::type()
+{
+    return typeAsString();
 }
 
 ::mstch::node CXXRecord::namespaceScope()

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -217,6 +217,13 @@ bool chimera::Visitor::GenerateCXXRecord(CXXRecordDecl *decl)
     // Serialize using a mstch template.
     auto context = std::make_shared<chimera::mstch::CXXRecord>(
         config_, decl, &traversed_class_decls_);
+
+    // TODO(#148): Workaround to skip generating class binding that is
+    // unintentionally generated for lambda function in header. See #148 for the
+    // details.
+    if (context->typeAsString() == "(lambda)")
+        return false;
+
     return config_.Render(context);
 }
 

--- a/test/examples/regression/CMakeLists.txt
+++ b/test/examples/regression/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(issue148_lambda_function)
 add_subdirectory(issue216_template_param)
 add_subdirectory(issue228_template_type_alias)

--- a/test/examples/regression/issue148_lambda_function/CMakeLists.txt
+++ b/test/examples/regression/issue148_lambda_function/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(test_name "issue148_lambda_function")
+
+chimera_add_binding_test_pybind11(${test_name}_pybind11
+  SOURCES ${test_name}.h
+  EXTRA_SOURCES ${test_name}.cpp
+  NAMESPACES chimera_test
+  CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/pybind11.yaml
+  COPY_MODULE
+)
+
+chimera_add_binding_test_boost_python(${test_name}_boost_python
+  SOURCES ${test_name}.h
+  EXTRA_SOURCES ${test_name}.cpp
+  NAMESPACES chimera_test
+  CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/boost_python.yaml
+  COPY_MODULE
+)
+
+chimera_add_python_test(${test_name}_python_tests ${test_name}.py)

--- a/test/examples/regression/issue148_lambda_function/boost_python.yaml
+++ b/test/examples/regression/issue148_lambda_function/boost_python.yaml
@@ -1,0 +1,7 @@
+# Arguments that will be appended in-order before command line arguments.
+arguments:
+  - "-extra-arg"
+  - "-I/usr/lib/clang/3.6/include"
+namespaces:
+  'chimera_test':
+    name: null # TODO: otherwise, import error

--- a/test/examples/regression/issue148_lambda_function/issue148_lambda_function.cpp
+++ b/test/examples/regression/issue148_lambda_function/issue148_lambda_function.cpp
@@ -1,0 +1,8 @@
+#include "issue148_lambda_function.h"
+
+namespace chimera_test
+{
+
+//==============================================================================
+
+} // namespace chimera_test

--- a/test/examples/regression/issue148_lambda_function/issue148_lambda_function.h
+++ b/test/examples/regression/issue148_lambda_function/issue148_lambda_function.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <functional>
+
+namespace chimera_test
+{
+
+inline std::function<void()> foo()
+{
+    return [] {};
+}
+
+} // namespace chimera_test

--- a/test/examples/regression/issue148_lambda_function/issue148_lambda_function.py
+++ b/test/examples/regression/issue148_lambda_function/issue148_lambda_function.py
@@ -1,0 +1,18 @@
+import unittest
+
+import issue148_lambda_function_pybind11 as py11
+import issue148_lambda_function_boost_python as boost
+
+
+class TestFunction(unittest.TestCase):
+
+    def _test_lambda_function(self, binding):
+        pass
+
+    def test_lambda_function(self):
+        self._test_lambda_function(py11)
+        self._test_lambda_function(boost)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/examples/regression/issue148_lambda_function/pybind11.yaml
+++ b/test/examples/regression/issue148_lambda_function/pybind11.yaml
@@ -1,0 +1,7 @@
+# Arguments that will be appended in-order before command line arguments.
+arguments:
+  - "-extra-arg"
+  - "-I/usr/lib/clang/3.6/include"
+namespaces:
+  'chimera_test':
+    name: null # TODO: otherwise, import error


### PR DESCRIPTION
This PR suppresses #148 by skipping generating class binding that is being generated for lambda function defined in a header. We can safely skip the binding because the function contains the lambda function (i.e., `foo()` in the test) is still generated.