### PR TITLE
Ignore unspecialized template variables

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1131,9 +1131,11 @@ std::string toString(const Decl *decl)
     else if (dyn_cast<TypeDecl>(decl))
         return "TypeDecl : NamedDecl";
     // ...
+#if LLVM_VERSION_AT_LEAST(6,0,0)
     else if (dyn_cast<DecompositionDecl>(decl))
         return "DecompositionDecl : VarDecl : DeclaratorDecl : ValueDecl : "
                "NamedDecl";
+#endif
     else if (dyn_cast<ImplicitParamDecl>(decl))
         return "ImplicitParamDecl : VarDecl : DeclaratorDecl : ValueDecl : "
                "NamedDecl";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -968,6 +968,10 @@ std::string toString(QualType qual_type)
 
 std::string toString(const Type *type)
 {
+    // Reference:
+    // https://clang.llvm.org/doxygen/classclang_1_1ExtQualsTypeCommonBase.html
+
+    // TODO: There are more types that are not handled.
     if (dyn_cast<DecayedType>(type))
         return "DecayedType : AdjustedType";
     else if (dyn_cast<AdjustedType>(type))
@@ -1080,15 +1084,15 @@ std::string toString(const Type *type)
 
 std::string toString(const Decl *decl)
 {
-    // TODO: Incomplete
+    // Reference: https://clang.llvm.org/doxygen/classclang_1_1Decl.html
+
+    // TODO: There are more types that are not handled.
     if (dyn_cast<AccessSpecDecl>(decl))
         return "AccessSpecDecl";
     else if (dyn_cast<BlockDecl>(decl))
         return "BlockDecl";
-    // ...
     else if (dyn_cast<LabelDecl>(decl))
         return "LabelDecl : NamedDecl";
-        // ...
 #if LLVM_VERSION_AT_LEAST(3, 9, 0)
     else if (dyn_cast<BuiltinTemplateDecl>(decl))
         return "BuiltinTemplateDecl : TemplateDecl : NamedDecl";
@@ -1111,7 +1115,6 @@ std::string toString(const Decl *decl)
         return "TemplateTemplateParmDecl : TemplateDecl : NamedDecl";
     else if (dyn_cast<TemplateDecl>(decl))
         return "TemplateDecl : NamedDecl";
-    // ...
     else if (dyn_cast<EnumDecl>(decl))
         return "EnumDecl : TagDecl : TypeDecl : NamedDecl";
     else if (dyn_cast<ClassTemplatePartialSpecializationDecl>(decl))
@@ -1127,11 +1130,9 @@ std::string toString(const Decl *decl)
         return "RecordDecl : TagDecl : TypeDecl : NamedDecl";
     else if (dyn_cast<TagDecl>(decl))
         return "TagDecl : TypeDecl : NamedDecl";
-    // ...
     else if (dyn_cast<TypeDecl>(decl))
         return "TypeDecl : NamedDecl";
-    // ...
-#if LLVM_VERSION_AT_LEAST(6,0,0)
+#if LLVM_VERSION_AT_LEAST(6, 0, 0)
     else if (dyn_cast<DecompositionDecl>(decl))
         return "DecompositionDecl : VarDecl : DeclaratorDecl : ValueDecl : "
                "NamedDecl";
@@ -1148,10 +1149,8 @@ std::string toString(const Decl *decl)
         return "VarDecl : DeclaratorDecl : ValueDecl : NamedDecl";
     else if (dyn_cast<DeclaratorDecl>(decl))
         return "DeclaratorDecl : ValueDecl : NamedDecl";
-    // ...
     else if (dyn_cast<ValueDecl>(decl))
         return "ValueDecl : NamedDecl";
-    // ...
     else if (dyn_cast<NamedDecl>(decl))
         return "NamedDecl";
     else if (dyn_cast<Decl>(decl))

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1131,6 +1131,25 @@ std::string toString(const Decl *decl)
     else if (dyn_cast<TypeDecl>(decl))
         return "TypeDecl : NamedDecl";
     // ...
+    else if (dyn_cast<DecompositionDecl>(decl))
+        return "DecompositionDecl : VarDecl : DeclaratorDecl : ValueDecl : "
+               "NamedDecl";
+    else if (dyn_cast<ImplicitParamDecl>(decl))
+        return "ImplicitParamDecl : VarDecl : DeclaratorDecl : ValueDecl : "
+               "NamedDecl";
+    else if (dyn_cast<ParmVarDecl>(decl))
+        return "ParmVarDecl : VarDecl : DeclaratorDecl : ValueDecl : NamedDecl";
+    else if (dyn_cast<VarTemplateSpecializationDecl>(decl))
+        return "VarTemplateSpecializationDecl : VarDecl : DeclaratorDecl : "
+               "ValueDecl : NamedDecl";
+    else if (dyn_cast<VarDecl>(decl))
+        return "VarDecl : DeclaratorDecl : ValueDecl : NamedDecl";
+    else if (dyn_cast<DeclaratorDecl>(decl))
+        return "DeclaratorDecl : ValueDecl : NamedDecl";
+    // ...
+    else if (dyn_cast<ValueDecl>(decl))
+        return "ValueDecl : NamedDecl";
+    // ...
     else if (dyn_cast<NamedDecl>(decl))
         return "NamedDecl";
     else if (dyn_cast<Decl>(decl))

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -240,6 +240,10 @@ bool chimera::Visitor::GenerateGlobalVar(clang::VarDecl *decl)
     // Ignore unspecialized template variables.
     else if (decl->getDescribedVarTemplate())
         return false;
+    // TODO(#297): Ignore specialized template variables because the current
+    // variable mastch and template not able to generate valid binding.
+    else if (isa<clang::VarTemplateSpecializationDecl>(decl))
+        return false;
 
     // TODO: Support return_value_policy for global variables.
     if (chimera::util::needsReturnValuePolicy(decl, decl->getType()))

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -248,7 +248,7 @@ bool chimera::Visitor::GenerateGlobalVar(clang::VarDecl *decl)
     else if (decl->getDescribedVarTemplate())
         return false;
     // TODO(#297): Ignore specialized template variables because the current
-    // variable mastch and template not able to generate valid binding.
+    // variable mastch template is not able to generate valid binding.
     else if (isa<clang::VarTemplateSpecializationDecl>(decl))
         return false;
 

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -248,7 +248,7 @@ bool chimera::Visitor::GenerateGlobalVar(clang::VarDecl *decl)
     else if (decl->getDescribedVarTemplate())
         return false;
     // TODO(#297): Ignore specialized template variables because the current
-    // variable mastch template is not able to generate valid binding.
+    // variable mstch template is not able to generate valid binding.
     else if (isa<clang::VarTemplateSpecializationDecl>(decl))
         return false;
 

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -237,6 +237,9 @@ bool chimera::Visitor::GenerateGlobalVar(clang::VarDecl *decl)
         return false;
     else if (!decl->isThisDeclarationADefinition())
         return false;
+    // Ignore unspecialized template variables.
+    else if (decl->getDescribedVarTemplate())
+        return false;
 
     // TODO: Support return_value_policy for global variables.
     if (chimera::util::needsReturnValuePolicy(decl, decl->getType()))

--- a/test/examples/regression/CMakeLists.txt
+++ b/test/examples/regression/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(issue216_template_param)
 add_subdirectory(issue228_template_type_alias)
+add_subdirectory(issue297_template_variable)

--- a/test/examples/regression/issue297_template_variable/CMakeLists.txt
+++ b/test/examples/regression/issue297_template_variable/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(test_name "issue297_template_variable")
+
+chimera_add_binding_test_pybind11(${test_name}_pybind11
+  SOURCES ${test_name}.h
+  EXTRA_SOURCES ${test_name}.cpp
+  NAMESPACES chimera_test
+  CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/pybind11.yaml
+  COPY_MODULE
+)
+
+chimera_add_binding_test_boost_python(${test_name}_boost_python
+  SOURCES ${test_name}.h
+  EXTRA_SOURCES ${test_name}.cpp
+  NAMESPACES chimera_test
+  CONFIGURATION ${CMAKE_CURRENT_SOURCE_DIR}/boost_python.yaml
+  COPY_MODULE
+)
+
+chimera_add_python_test(${test_name}_python_tests ${test_name}.py)

--- a/test/examples/regression/issue297_template_variable/boost_python.yaml
+++ b/test/examples/regression/issue297_template_variable/boost_python.yaml
@@ -1,0 +1,7 @@
+# Arguments that will be appended in-order before command line arguments.
+arguments:
+  - "-extra-arg"
+  - "-I/usr/lib/clang/3.6/include"
+namespaces:
+  "chimera_test":
+    name: null # TODO: otherwise, import error

--- a/test/examples/regression/issue297_template_variable/issue297_template_variable.cpp
+++ b/test/examples/regression/issue297_template_variable/issue297_template_variable.cpp
@@ -1,0 +1,8 @@
+#include "issue297_template_variable.h"
+
+namespace chimera_test
+{
+
+//==============================================================================
+
+} // namespace chimera_test

--- a/test/examples/regression/issue297_template_variable/issue297_template_variable.h
+++ b/test/examples/regression/issue297_template_variable/issue297_template_variable.h
@@ -8,4 +8,6 @@ namespace chimera_test
 template <typename T>
 constexpr bool template_var = std::true_type::value;
 
+constexpr bool specialized_var = template_var<int>;
+
 } // namespace chimera_test

--- a/test/examples/regression/issue297_template_variable/issue297_template_variable.h
+++ b/test/examples/regression/issue297_template_variable/issue297_template_variable.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <type_traits>
+
+namespace chimera_test
+{
+
+template <typename T>
+constexpr bool template_var = std::true_type::value;
+
+} // namespace chimera_test

--- a/test/examples/regression/issue297_template_variable/issue297_template_variable.py
+++ b/test/examples/regression/issue297_template_variable/issue297_template_variable.py
@@ -8,6 +8,7 @@ class TestIssue297(unittest.TestCase):
 
     def _test_issue297(self, binding):
         self.assertFalse(hasattr(binding, 'template_var'))
+        self.assertTrue(hasattr(binding, 'specialized_var'))
 
     def test_issue297(self):
         self._test_issue297(py11)

--- a/test/examples/regression/issue297_template_variable/issue297_template_variable.py
+++ b/test/examples/regression/issue297_template_variable/issue297_template_variable.py
@@ -1,0 +1,17 @@
+import unittest
+
+import issue297_template_variable_pybind11 as py11
+import issue297_template_variable_boost_python as boost
+
+
+class TestIssue297(unittest.TestCase):
+
+    def _test_issue297(self, binding):
+        self.assertFalse(hasattr(binding, 'template_var'))
+
+    def test_issue297(self):
+        self._test_issue297(py11)
+        self._test_issue297(boost)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/examples/regression/issue297_template_variable/pybind11.yaml
+++ b/test/examples/regression/issue297_template_variable/pybind11.yaml
@@ -1,0 +1,7 @@
+# Arguments that will be appended in-order before command line arguments.
+arguments:
+  - "-extra-arg"
+  - "-I/usr/lib/clang/3.6/include"
+namespaces:
+  "chimera_test":
+    name: null # TODO: otherwise, import error


### PR DESCRIPTION
The variable template is a C++14 feature. We need to (1) check which LLVM version added function `decl->getDescribedVarTemplate()` and (2) enable the test only when Chimera is built with C++14 supported compiler.

Fixes #297 