### PR TITLE
Use lookupYAMLNode to safely check empty config nodes.

### DIFF
--- a/include/chimera/mstch.h
+++ b/include/chimera/mstch.h
@@ -85,7 +85,7 @@ public:
 
     virtual ::std::string nameAsString()
     {
-        if (const YAML::Node node = decl_config_["name"])
+        if (const YAML::Node node = lookupYAMLNode(decl_config_, "name"))
         {
             // Convert a `null` to an empty string.
             // This helps users semantically mark names that should be
@@ -108,7 +108,8 @@ public:
 
     virtual ::mstch::node mangledName()
     {
-        if (const YAML::Node node = decl_config_["mangled_name"])
+        if (const YAML::Node node
+            = lookupYAMLNode(decl_config_, "mangled_name"))
             return node.as<std::string>();
 
         return chimera::util::constructMangledName(decl_);
@@ -137,7 +138,8 @@ public:
 
     virtual ::mstch::node qualifiedName()
     {
-        if (const YAML::Node node = decl_config_["qualified_name"])
+        if (const YAML::Node node
+            = lookupYAMLNode(decl_config_, "qualified_name"))
             return node.as<std::string>();
 
         return decl_->getQualifiedNameAsString();

--- a/include/chimera/util.h
+++ b/include/chimera/util.h
@@ -61,14 +61,14 @@ template <typename... Args>
 YAML::Node lookupYAMLNode(const YAML::Node &node, const std::string &key,
                           Args &&... args)
 {
-    // Return if 'node' is invalid
-    if (not node)
+    // Return if 'node' is invalid.
+    if (!node)
         return node;
 
     auto next = node[key];
 
-    // Return if failed to find a tag of 'key'
-    if (not next)
+    // Return if failed to find a tag of 'key'.
+    if (!next)
         return next;
 
     // Lookup for the next nested tags

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -169,8 +169,8 @@ const std::string &chimera::Configuration::GetOutputModuleName() const
 chimera::CompiledConfiguration::CompiledConfiguration(
     const chimera::Configuration &parent, CompilerInstance *ci)
   : parent_(parent)
-  , configNode_(parent.GetRoot())         // TODO: do we need this reference?
-  , bindingNode_(configNode_["template"]) // TODO: is this always ok?
+  , configNode_(parent.GetRoot()) // TODO: do we need this reference?
+  , bindingNode_(chimera::util::lookupYAMLNode(configNode_, "template"))
   , ci_(ci)
 {
     // This placeholder will be filled in by the options.strict specified


### PR DESCRIPTION
This addresses a bug where namespace entries need to have a spurious blank name entry because leaving them empty makes them null.