### PR TITLE
Provide an option to change static method name when it conflicts with instance name

### DIFF
--- a/include/chimera/configuration.h
+++ b/include/chimera/configuration.h
@@ -120,14 +120,28 @@ protected:
 class CompiledConfiguration
 {
 public:
+    enum class StaticMethodNamePolicy
+    {
+        NO_CHANGE,
+        FIRST_LETTER_CAPITAL,
+        CAPITAL,
+        // TODO: Add more policies such as prefix and suffix
+    };
+
     virtual ~CompiledConfiguration() = default;
     CompiledConfiguration(const CompiledConfiguration &) = delete;
     CompiledConfiguration &operator=(const CompiledConfiguration &) = delete;
 
     /**
-     * Return whether to treat unresolvable configuration as errors.
+     * Returns whether to treat unresolvable configuration as errors.
      */
     bool GetStrict() const;
+
+    /**
+     * Returns policy for the case that a static method has a same name one of
+     * the instance method names in the same class.
+     */
+    StaticMethodNamePolicy GetStaticMethodNamePolicy() const;
 
     /**
      * Adds a namespace to an ordered set of traversed namespaces.
@@ -258,6 +272,7 @@ protected:
     std::set<const clang::NamespaceDecl *> binding_namespace_decls_;
 
     bool strict_;
+    StaticMethodNamePolicy static_method_name_policy_;
 
     friend class Configuration;
 };

--- a/include/chimera/mstch.h
+++ b/include/chimera/mstch.h
@@ -307,13 +307,19 @@ public:
            const clang::CXXMethodDecl *decl,
            const clang::CXXRecordDecl *class_decl = nullptr);
 
+    void setNameConflict(bool val);
+    bool isNameConflict() const;
+
+    std::string nameAsString() override;
     ::mstch::node isConst();
+    bool isStaticAsBool() const;
     ::mstch::node isStatic();
     ::mstch::node isVirtual();
     ::mstch::node isPureVirtual();
 
 private:
     const clang::CXXMethodDecl *method_decl_;
+    bool name_conflict_;
 };
 
 class Namespace : public ClangWrapper<clang::NamespaceDecl>

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -193,6 +193,26 @@ chimera::CompiledConfiguration::CompiledConfiguration(
         config_options_strict = strictNode.as<bool>();
     }
 
+    // Parse 'options.static_method_name_policy' to set the static method name
+    // policy for the case a static method has the same name one of the instance
+    // methods in the same class.
+    static_method_name_policy_ = StaticMethodNamePolicy::NO_CHANGE;
+    const YAML::Node staticMethodNamePolicyNode = chimera::util::lookupYAMLNode(
+        configNode_, "options", "static_method_name_policy");
+    if (staticMethodNamePolicyNode)
+    {
+        const std::string policy = staticMethodNamePolicyNode.as<std::string>();
+        if (policy == "first_letter_capital")
+        {
+            static_method_name_policy_
+                = StaticMethodNamePolicy::FIRST_LETTER_CAPITAL;
+        }
+        else if (policy == "capital")
+        {
+            static_method_name_policy_ = StaticMethodNamePolicy::CAPITAL;
+        }
+    }
+
     // Set the options.strict from one of the following sources in order of
     // priority: 1) CLI '-strict' setting (True if -strict passed, False
     // otherwise) 2) YAML configuration setting (True/False) 3) false by default
@@ -476,6 +496,12 @@ chimera::CompiledConfiguration::CompiledConfiguration(
 bool chimera::CompiledConfiguration::GetStrict() const
 {
     return strict_;
+}
+
+chimera::CompiledConfiguration::StaticMethodNamePolicy
+chimera::CompiledConfiguration::GetStaticMethodNamePolicy() const
+{
+    return static_method_name_policy_;
 }
 
 void chimera::CompiledConfiguration::AddTraversedNamespace(

--- a/test/examples/02_class/class.h
+++ b/test/examples/02_class/class.h
@@ -99,4 +99,28 @@ class ClassInDetail
 
 } // namespace detail
 
+namespace test1
+{
+
+class Integer
+{
+public:
+    Integer(int val) : m_val(val)
+    {
+    }
+    int add(int a)
+    {
+        return a + m_val;
+    }
+    static int add(int a, int b)
+    {
+        return a + b;
+    }
+
+private:
+    int m_val;
+};
+
+} // namespace test1
+
 } // namespace chimera_test

--- a/test/examples/02_class/class.py
+++ b/test/examples/02_class/class.py
@@ -10,92 +10,60 @@ except:
 import class_boost_python as boost
 
 
-class TestFunction(unittest.TestCase):
+class TestClass(unittest.TestCase):
 
-    def test_function_py11(self):
-        if not has_pybind11:
-            return
-
-        dog = py11.Dog()
+    def _test_class(self, binding):
+        dog = binding.Dog()
         self.assertEqual(dog.type(), 'Dog')
         self.assertEqual(dog.pure_virtual_type(), 'Dog')
-        self.assertEqual(py11.Dog.static_type(), 'Dog')
+        self.assertEqual(binding.Dog.static_type(), 'Dog')
 
-        husky = py11.Husky()
+        husky = binding.Husky()
         self.assertEqual(husky.type(), 'Husky')
         self.assertEqual(husky.pure_virtual_type(), 'Husky')
 
-        strong_husky = py11.StrongHusky()
+        strong_husky = binding.StrongHusky()
         self.assertEqual(strong_husky.type(), 'StrongHusky')
         self.assertEqual(strong_husky.pure_virtual_type(), 'StrongHusky')
 
-        default_args = py11.DefaultArguments()
+        default_args = binding.DefaultArguments()
         self.assertEqual(default_args.add(), 3)
         self.assertEqual(default_args.add(2), 4)
         self.assertEqual(default_args.add(2, 3), 5)
 
-        self.assertEqual(py11.StaticFields.m_static_readonly_type, 'static readonly type')
-        self.assertEqual(py11.StaticFields.m_static_readwrite_type, 'static readwrite type')
-        py11.StaticFields.m_static_readwrite_type = 'new type'
-        self.assertEqual(py11.StaticFields.m_static_readwrite_type, 'new type')
-        self.assertEqual(py11.StaticFields.static_type(), 'static type')
-
-        non_pub_param_in_ctr = py11.NonPublicParamInConstructor('Herb')
-        self.assertEqual(non_pub_param_in_ctr.m_name, 'Herb')
-
-        # Check if the main class and the nested class can be created w/o errors
-        mc = py11.MainClass()
-        nc = py11.MainClass.NestedClass()
-
-        # MainClass shouldn't be a module
-        self.assertFalse(inspect.ismodule(py11.MainClass))
-        self.assertTrue(inspect.isclass(py11.MainClass))
-        self.assertTrue(inspect.isclass(py11.MainClass.NestedClass))
-
-        import class_pybind11
-        self.assertFalse(hasattr(class_pybind11, 'detail'))
-
-    def test_function_bp(self):
-        dog = boost.Dog()
-        self.assertEqual(dog.type(), 'Dog')
-        self.assertEqual(dog.pure_virtual_type(), 'Dog')
-        self.assertEqual(boost.Dog.static_type(), 'Dog')
-
-        husky = boost.Husky()
-        self.assertEqual(husky.type(), 'Husky')
-        self.assertEqual(husky.pure_virtual_type(), 'Husky')
-
-        strong_husky = boost.StrongHusky()
-        self.assertEqual(strong_husky.type(), 'StrongHusky')
-        self.assertEqual(strong_husky.pure_virtual_type(), 'StrongHusky')
-
-        default_args = boost.DefaultArguments()
-        self.assertEqual(default_args.add(), 3)
-        self.assertEqual(default_args.add(2), 4)
-        self.assertEqual(default_args.add(2, 3), 5)
-
-        self.assertEqual(boost.StaticFields.m_static_readonly_type, 'static readonly type')
-        self.assertEqual(boost.StaticFields.m_static_readwrite_type, 'static readwrite type')
+        self.assertEqual(binding.StaticFields.m_static_readonly_type, 'static readonly type')
+        self.assertEqual(binding.StaticFields.m_static_readwrite_type, 'static readwrite type')
         # TODO(JS): Boost.Python doesn't work for readwrite static field (see: #194)
-        # boost.StaticFields.m_static_readwrite_type = 'new type'
-        # self.assertEqual(boost.StaticFields.m_static_readwrite_type, 'new type')
-        self.assertEqual(boost.StaticFields.static_type(), 'static type')
+        if has_pybind11 and binding is py11:
+            binding.StaticFields.m_static_readwrite_type = 'new type'
+            self.assertEqual(binding.StaticFields.m_static_readwrite_type, 'new type')
+        self.assertEqual(binding.StaticFields.static_type(), 'static type')
 
-        non_pub_param_in_ctr = boost.NonPublicParamInConstructor('Herb')
+        non_pub_param_in_ctr = binding.NonPublicParamInConstructor('Herb')
         self.assertEqual(non_pub_param_in_ctr.m_name, 'Herb')
 
         # Check if the main class and the nested class can be created w/o errors
-        mc = boost.MainClass()
-        nc = boost.MainClass.NestedClass()
+        mc = binding.MainClass()
+        nc = binding.MainClass.NestedClass()
 
         # MainClass shouldn't be a module
-        self.assertFalse(inspect.ismodule(boost.MainClass))
-        self.assertTrue(inspect.isclass(boost.MainClass))
-        self.assertTrue(inspect.isclass(boost.MainClass.NestedClass))
+        self.assertFalse(inspect.ismodule(binding.MainClass))
+        self.assertTrue(inspect.isclass(binding.MainClass))
+        self.assertTrue(inspect.isclass(binding.MainClass.NestedClass))
 
-        import class_boost_python
-        self.assertFalse(hasattr(class_boost_python, 'detail'))
+        self.assertFalse(hasattr(binding, 'detail'))
 
+        # Call static method
+        self.assertEqual(binding.test1.Integer.Add(1, 2), 3)
+        
+        # Call instance method
+        i = binding.test1.Integer(1)
+        self.assertEqual(i.add(2), 3)
+
+    def test_class(self):
+        self._test_class(boost)
+        if has_pybind11:
+            self._test_class(py11)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/examples/02_class/class.yaml
+++ b/test/examples/02_class/class.yaml
@@ -2,7 +2,9 @@
 arguments:
   - "-extra-arg"
   - "-I/usr/lib/clang/3.6/include"
+options:
+  static_method_name_policy: "first_letter_capital"
 namespaces:
-  'chimera_test':
+  "chimera_test":
     name: null # TODO: otherwise, import error
-  'chimera_test::detail': null
+  "chimera_test::detail": null


### PR DESCRIPTION
chimera only print warnings if a static method has the same name with instance methods in the same class (when `class.static_methods` is used in the template).

However, method overloading for instance and static methods with the same name is not also supported by the native Python. Also, bindings generated using pybind11 cause runtime error.

It would make more sense to either not generating static (or instance) method for the case or change one of the names.

This PR is a possible solution for this issue by providing an option on how to change a static method when the name is conflicting.

Related issue #262.