### PR TITLE
Use std::cerr for warnings

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -268,7 +268,7 @@ chimera::CompiledConfiguration::CompiledConfiguration(
                     }
                     else
                     {
-                        std::cout << "Warning: Skipped namespace namespace '"
+                        std::cerr << "Warning: Skipped namespace namespace '"
                                   << ns_str
                                   << "' because it's unable to resolve "
                                   << "the namespace." << std::endl;
@@ -324,7 +324,7 @@ chimera::CompiledConfiguration::CompiledConfiguration(
                 }
                 else
                 {
-                    std::cout
+                    std::cerr
                         << "Warning: Skipped the configuration for class '"
                         << decl_str << "' becuase it's "
                         << "unable to resolve the class declaration."
@@ -363,7 +363,7 @@ chimera::CompiledConfiguration::CompiledConfiguration(
                     }
                     else
                     {
-                        std::cout
+                        std::cerr
                             << "Warning: Skipped the configuration for "
                             << "function '" << decl_str << "' becuase it's "
                             << "unable to resolve the function declaration."
@@ -402,7 +402,7 @@ chimera::CompiledConfiguration::CompiledConfiguration(
                     }
                     else
                     {
-                        std::cout << "Warning: Skipped the configuration for "
+                        std::cerr << "Warning: Skipped the configuration for "
                                   << "type '" << type_str << "' becuase it's "
                                   << "unable to resolve the type." << std::endl;
                         continue;


### PR DESCRIPTION
Otherwise, the warnings are regarded as the binding file name, which is an error.