### PR TITLE
Increase minimum required LLVM version to 6.0

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -2,7 +2,7 @@
 # Ref: https://docs.microsoft.com/en-us/azure/devops/pipelines
 
 jobs:
-- job: ubuntu_xenial_gcc_release_llvm3_9
+- job: ubuntu_xenial_gcc_release_llvm6_0
   pool:
     vmImage: 'ubuntu-18.04'
   variables:
@@ -16,7 +16,7 @@ jobs:
   steps:
   - template: .ci/azure-pipelines/docker.yml
 
-- job: ubuntu_xenial_clang_release_llvm3_9
+- job: ubuntu_xenial_clang_release_llvm6_0
   pool:
     vmImage: 'ubuntu-18.04'
   variables:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
     COMPILER: gcc
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 3.9
+    LLVM_VERSION: 6.0
     PYTHON_VERSION: 3.5
     DOCKERFILE: Dockerfile.ubuntu-xenial
   steps:
@@ -24,7 +24,7 @@ jobs:
     COMPILER: clang
     BUILD_TYPE: Release
     BUILD_DIR: $(Build.SourcesDirectory)
-    LLVM_VERSION: 3.9
+    LLVM_VERSION: 6.0
     PYTHON_VERSION: 3.5
     DOCKERFILE: Dockerfile.ubuntu-xenial
   steps:

--- a/.ci/install_macos.sh
+++ b/.ci/install_macos.sh
@@ -79,11 +79,7 @@ if check_version "${LLVM_VERSION}" '=' "${LLVM_VERSION_LATEST}"; then
   LLVM_INSTALL_PREFIX='llvm'
 else
   LLVM_PACKAGE="llvm@${LLVM_VERSION}"
-  if check_version "${LLVM_VERSION}" '>=' "3.9"; then
-    LLVM_INSTALL_PREFIX="llvm"
-  else
-    LLVM_INSTALL_PREFIX="llvm-${LLVM_VERSION}"
-  fi
+  LLVM_INSTALL_PREFIX="llvm"
 
   if ! brew info "${LLVM_PACKAGE}" > /dev/null 2> /dev/null; then
     echo "error: There is no package Homebrew package named '${LLVM_PACKAGE}'"\
@@ -92,13 +88,8 @@ else
   fi
 fi
 
-# Infer the correct value of CMAKE_PREFIX_PATH for this version of LLVM. This
-# directory was changed between LLVM versions 3.8 and 3.9.
-if check_version "${LLVM_VERSION}" '>=' '3.9'; then
-  LLVM_DIR="$(brew --prefix ${LLVM_PACKAGE})/lib/cmake/${LLVM_INSTALL_PREFIX}"
-else
-  LLVM_DIR="$(brew --prefix ${LLVM_PACKAGE})/lib/${LLVM_INSTALL_PREFIX}/share/llvm/cmake"
-fi
+# Infer the correct value of CMAKE_PREFIX_PATH for this version of LLVM.
+LLVM_DIR="$(brew --prefix ${LLVM_PACKAGE})/lib/cmake/${LLVM_INSTALL_PREFIX}"
 export LLVM_DIR
 
 echo $LLVM_DIR

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,7 +24,7 @@ jobs:
           OS_NAME: linux
           COMPILER: gcc
           BUILD_TYPE: Release
-          LLVM_VERSION: 3.9
+          LLVM_VERSION: 6.0
           PYTHON_VERSION: 3.5
           DOCKERFILE: Dockerfile.ubuntu-xenial
         run: |
@@ -45,7 +45,7 @@ jobs:
           OS_NAME: linux
           COMPILER: gcc
           BUILD_TYPE: Release
-          LLVM_VERSION: "6.0"
+          LLVM_VERSION: 6.0
           PYTHON_VERSION: 3.6
           DOCKERFILE: Dockerfile.ubuntu-bionic
         run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   xenial_gcc_release:
-    name: xenial_gcc_release_llvm3_9
+    name: xenial_gcc_release_llvm6_0
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
@@ -24,7 +24,7 @@ jobs:
           OS_NAME: linux
           COMPILER: gcc
           BUILD_TYPE: Release
-          LLVM_VERSION: 6.0
+          LLVM_VERSION: "6.0"
           PYTHON_VERSION: 3.5
           DOCKERFILE: Dockerfile.ubuntu-xenial
         run: |
@@ -36,7 +36,7 @@ jobs:
           docker exec chimera-docker /bin/sh -c "cd $GITHUB_WORKSPACE && . .ci/script.sh";
 
   bionic_gcc_release:
-    name: bionic_gcc_release_llvm6
+    name: bionic_gcc_release_llvm6_0
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
@@ -45,7 +45,7 @@ jobs:
           OS_NAME: linux
           COMPILER: gcc
           BUILD_TYPE: Release
-          LLVM_VERSION: 6.0
+          LLVM_VERSION: "6.0"
           PYTHON_VERSION: 3.6
           DOCKERFILE: Dockerfile.ubuntu-bionic
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - os: linux
       compiler: gcc
       env:
-        - BUILD_NAME=XENIAL_GCC_DEBUG_LLVM3_9
+        - BUILD_NAME=XENIAL_GCC_DEBUG_LLVM6_0
         - BUILD_TYPE=Debug
         - COMPILER=GCC
         - LLVM_VERSION=6.0
@@ -27,7 +27,7 @@ matrix:
     - os: linux
       compiler: gcc
       env:
-        - BUILD_NAME=BIONIC_GCC_DEBUG_LLVM6
+        - BUILD_NAME=BIONIC_GCC_DEBUG_LLVM6_0
         - BUILD_TYPE=Debug
         - COMPILER=GCC
         - LLVM_VERSION=6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
         - BUILD_NAME=XENIAL_GCC_DEBUG_LLVM3_9
         - BUILD_TYPE=Debug
         - COMPILER=GCC
-        - LLVM_VERSION=3.9
+        - LLVM_VERSION=6.0
         - PYTHON_VERSION=3.5
         - DOCKERFILE="Dockerfile.ubuntu-xenial"
       services: docker

--- a/README.md
+++ b/README.md
@@ -28,16 +28,7 @@ $ ./chimera -c <yaml_config_file> -o <output_path> my_cpp_header1.h my_cpp_heade
 
 ### On Ubuntu using `apt`
 
-Chimera provides Ubuntu packages for Trusty (14.04 LTS), Xenial (16.04 LTS), Bionic (18.04 LTS), and Eoan (19.10).
-
-**Trusty**
-
-```shell
-$ sudo add-apt-repository ppa:personalrobotics/ppa
-$ sudo add-apt-repository ppa:renemilk/llvm
-$ sudo apt update
-$ sudo apt install chimera
-```
+Chimera provides Ubuntu packages for Xenial (16.04 LTS), Bionic (18.04 LTS), Eoan (19.10), and Focal (20.04).
 
 **Xenial and greater**
 
@@ -62,8 +53,8 @@ $ brew install chimera
 
 ### Requirements
 
-* libclang 3.6, 3,9 or 6.0, 7, 8, 9
-* llvm 3.6, 3,9, 6.0, 7, 8, 9 (+ tools)
+* libclang 6.0, 7, 8, 9
+* llvm 6.0, 7, 8, 9 (+ tools)
 * libedit
 * yaml-cpp
 * boost
@@ -72,19 +63,10 @@ $ brew install chimera
 
 #### Install Dependencies
 
-**Trusty**
-
-```bash
-$ sudo apt-add-repository ppa:george-edison55/cmake-3.x
-$ sudo apt-get update
-$ sudo apt-get install cmake
-$ sudo apt-get install llvm-3.7-dev llvm-3.7-tools libclang-3.7-dev libedit-dev libyaml-cpp-dev libboost-dev lib32z1-dev
-```
-
 **Xenial**
 
 ```bash
-$ sudo apt-get install llvm-3.9-dev llvm-3.9-tools libclang-3.9-dev libedit-dev libyaml-cpp-dev libboost-dev lib32z1-dev
+$ sudo apt-get install llvm-6.0-dev llvm-6.0-tools libclang-6.0-dev libedit-dev libyaml-cpp-dev libboost-dev lib32z1-dev
 ```
 
 **Bionic and greater**

--- a/README.md
+++ b/README.md
@@ -63,16 +63,9 @@ $ brew install chimera
 
 #### Install Dependencies
 
-**Xenial**
-
 ```bash
-$ sudo apt-get install llvm-6.0-dev llvm-6.0-tools libclang-6.0-dev libedit-dev libyaml-cpp-dev libboost-dev lib32z1-dev
-```
-
-**Bionic and greater**
-
-```bash
-$ sudo apt-get install llvm-6.0-dev llvm-6.0-tools libclang-6.0-dev libedit-dev libyaml-cpp-dev libboost-dev lib32z1-dev
+$ sudo apt-get install llvm-6.0-dev llvm-6.0-tools libclang-6.0-dev libedit-dev \
+$   libyaml-cpp-dev libboost-dev lib32z1-dev
 ```
 
 #### Build Chimera

--- a/cmake/chimeraFindLLVM.cmake
+++ b/cmake/chimeraFindLLVM.cmake
@@ -34,7 +34,7 @@ endif()
 #
 # Note that LLVM >= 7 causes memory leaks in chimera::util::resolveDeclaration()
 # See https://github.com/personalrobotics/chimera/issues/222
-set(COMPATIBLE_LLVM_VERSIONS 3.6 3.9 6.0 8.0 9.0 10.0)
+set(COMPATIBLE_LLVM_VERSIONS 6.0 7.0 8.0 9.0)
 set(LLVM_VERSION_MAJOR_MINOR ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR})
 set(FOUND_COMPATIBLE_LLVM FALSE)
 foreach(version ${COMPATIBLE_LLVM_VERSIONS})

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1023,14 +1023,12 @@ std::string toString(const Type *type)
         return "DecltypeType";
     else if (dyn_cast<AutoType>(type))
         return "AutoType : DeducedType";
-#if LLVM_VERSION_AT_LEAST(6, 0, 0)
     else if (dyn_cast<DeducedTemplateSpecializationType>(type))
         return "DeducedTemplateSpecializationType : DecudedType";
     else if (dyn_cast<DeducedType>(type))
         return "DeducedType";
     else if (dyn_cast<DependentAddressSpaceType>(type))
         return "DependentAddressSpaceType";
-#endif
     else if (dyn_cast<DependentSizedExtVectorType>(type))
         return "DependentSizedExtVectorType";
 #if LLVM_VERSION_AT_LEAST(8, 0, 0)
@@ -1065,18 +1063,14 @@ std::string toString(const Type *type)
 #endif
     else if (dyn_cast<ObjCObjectType>(type))
         return "ObjCObjectType";
-#if LLVM_VERSION_AT_LEAST(6, 0, 0)
     else if (dyn_cast<ObjCTypeParamType>(type))
         return "ObjCTypeParamType";
-#endif
     else if (dyn_cast<PackExpansionType>(type))
         return "PackExpansionType";
     else if (dyn_cast<ParenType>(type))
         return "ParenType";
-#if LLVM_VERSION_AT_LEAST(3, 9, 0)
     else if (dyn_cast<PipeType>(type))
         return "PipeType";
-#endif
     else if (dyn_cast<PointerType>(type))
         return "PointerType";
 #if LLVM_VERSION_AT_LEAST(8, 0, 0)
@@ -1156,10 +1150,8 @@ std::string toString(const Decl *decl)
         return "BlockDecl";
     else if (dyn_cast<LabelDecl>(decl))
         return "LabelDecl : NamedDecl";
-#if LLVM_VERSION_AT_LEAST(3, 9, 0)
     else if (dyn_cast<BuiltinTemplateDecl>(decl))
         return "BuiltinTemplateDecl : TemplateDecl : NamedDecl";
-#endif
 #if LLVM_VERSION_AT_LEAST(10, 0, 0)
     else if (dyn_cast<ConceptDecl>(decl))
         return "ConceptDecl : TemplateDecl : NamedDecl";
@@ -1219,11 +1211,9 @@ std::string toString(const Decl *decl)
 #endif
     else if (dyn_cast<FieldDecl>(decl))
         return "FieldDecl : DeclaratorDecl : ValueDecl : NamedDecl";
-#if LLVM_VERSION_AT_LEAST(6, 0, 0)
     else if (dyn_cast<CXXDeductionGuideDecl>(decl))
         return "CXXDeductionGuideDecl : FunctionDecl : DeclaratorDecl : "
                "ValueDecl : NamedDecl";
-#endif
     else if (dyn_cast<CXXConstructorDecl>(decl))
         return "CXXConstructorDecl : CXXMethodDecl : FunctionDecl : "
                "DeclaratorDecl : ValueDecl : NamedDecl";
@@ -1243,23 +1233,17 @@ std::string toString(const Decl *decl)
     else if (dyn_cast<NonTypeTemplateParmDecl>(decl))
         return "NonTypeTemplateParmDecl : DeclaratorDecl : ValueDecl : "
                "NamedDecl";
-#if LLVM_VERSION_AT_LEAST(6, 0, 0)
     else if (dyn_cast<UsingDecl>(decl))
         return "UsingDecl : NamedDecl";
-#endif
     else if (dyn_cast<UsingDirectiveDecl>(decl))
         return "UsingDirectiveDecl : NamedDecl";
-#if LLVM_VERSION_AT_LEAST(6, 0, 0)
     else if (dyn_cast<UsingPackDecl>(decl))
         return "UsingPackDecl : NamedDecl";
-#endif
     else if (dyn_cast<UsingShadowDecl>(decl))
         return "UsingShadowDecl : NamedDecl";
-#if LLVM_VERSION_AT_LEAST(6, 0, 0)
     else if (dyn_cast<DecompositionDecl>(decl))
         return "DecompositionDecl : VarDecl : DeclaratorDecl : ValueDecl : "
                "NamedDecl";
-#endif
     else if (dyn_cast<ImplicitParamDecl>(decl))
         return "ImplicitParamDecl : VarDecl : DeclaratorDecl : ValueDecl : "
                "NamedDecl";

--- a/src/visitor.cpp
+++ b/src/visitor.cpp
@@ -324,15 +324,8 @@ bool chimera::Visitor::GenerateTypedefName(TypedefNameDecl *decl)
     // Skip if the defining type is templated
     if (isa<TypeAliasDecl>(decl))
     {
-#if LLVM_VERSION_AT_LEAST(6, 0, 0)
         if (cast<TypeAliasDecl>(decl)->isTemplated())
             return false;
-#else
-        // TODO: Find a better way to check if the original type is templated
-        // declaration for LLVM < 6.0
-        if (chimera::util::endsWith(underlying_type_name, ">"))
-            return false;
-#endif
     }
 
     // Get the declaration from the underlying type


### PR DESCRIPTION
Drop supporting old LLVM versions. LLVM is available since Ubuntu 16.04, which is the oldest Ubuntu version that chimera currently supports.